### PR TITLE
WORKAROUND: Catch Error from Capacitor.Filesystem.deleteFile on Android or iOS Devices

### DIFF
--- a/src/app/utils/storage/storage.ts
+++ b/src/app/utils/storage/storage.ts
@@ -109,6 +109,8 @@ export class Storage<T extends object> {
       concatMap(hash => Filesystem.deleteFile({
         path: `${this.name}/${hash}.json`,
         directory: this.directory
-      })));
+      })),
+      catchError((err: Error) => of(console.log(`err: ${err}, tuple: ${JSON.stringify(tuple)}`)))
+    );
   }
 }


### PR DESCRIPTION
WORKAROUND: Catch error throw on deleting files.

Rationale (zh-tw)

app 使用的儲存方式是依靠 Capacitor 這個 lib 來幫我們處理不同平台的資料儲存。但是這個 lib 有不少問題與限制，舉例而言，在 Android 上它偶爾會刪不掉先前透過它儲存的檔案，然後回傳的錯誤訊息也很不明確。因為發送 PostCapture 之後要刪掉相關的檔案，然後 Capacitor 刪除過程發生錯誤，因此中斷了這個行為，而沒有自動跳回 Capture 頁面。目前最快的 workaround 是直接 catch 掉所有  Capacitor.Filesystem.deleteFile()  產生的錯誤訊息。但是這個解決方法很爛，而且只會讓未來越來越難 debug。