### PR TITLE
Fix the get Asset URL to prevent auth header to be dropped on iOS

### DIFF
--- a/src/app/services/publisher/numbers-storage/numbers-storage-api.service.ts
+++ b/src/app/services/publisher/numbers-storage/numbers-storage-api.service.ts
@@ -96,7 +96,7 @@ export class NumbersStorageApi {
 
   readAsset$(id: string) {
     return this.getHttpHeadersWithAuthToken$().pipe(
-      concatMap(headers => this.httpClient.get<Asset>(`${baseUrl}/api/v2/assets/${id}`, { headers }))
+      concatMap(headers => this.httpClient.get<Asset>(`${baseUrl}/api/v2/assets/${id}/`, { headers }))
     );
   }
 


### PR DESCRIPTION
## Fixes

- iOS inbox accept fails

Safari and iOS Webview implement a strict policy on HTTP redirection, dropping the auth headers on HTTP 301 redirect which is the behavior when the API receives a url not ended with slash.