### PR TITLE
Implement the not-uploaded overlay and re-upload click event for Captures

### DIFF
--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -45,7 +45,8 @@
           [matBadge]="inboxCount$ | async"
           [matBadgeHidden]="!(inboxCount$ | async)"
           matBadgeColor="warn"
-          >all_inbox</mat-icon
+        >
+          all_inbox</mat-icon
         >
       </button>
     </mat-toolbar>
@@ -61,17 +62,44 @@
           >
             <div class="mat-title">{{ captureByDate.key }}</div>
             <mat-grid-list cols="3" gutterSize="8px">
-              <mat-grid-tile
-                *ngFor="let capture of captureByDate.value"
-                class="square-image-tile"
-                [style]="
-                  'background-image: url(data:image/*;base64,' +
-                  (capture.proofWithThumbnail.thumbnailBase64$ | async)! +
-                  ');'
-                "
-                [routerLink]="['asset', { id: capture.asset.id }]"
-              >
-              </mat-grid-tile>
+              <ng-container *ngFor="let capture of captureByDate.value">
+                <mat-grid-tile
+                  *ngIf="capture.asset"
+                  class="square-image-tile"
+                  [style.background]="
+                    'url(data:image/*;base64,' +
+                    (capture.proofWithThumbnail.thumbnailBase64$ | async)!
+                  "
+                  [routerLink]="['asset', { id: capture.asset.id }]"
+                >
+                </mat-grid-tile>
+                <ng-container *ngIf="!capture.asset">
+                  <mat-grid-tile
+                    class="square-image-tile"
+                    [style.background]="
+                      'url(data:image/*;base64,' +
+                      (capture.proofWithThumbnail.thumbnailBase64$ | async)!
+                    "
+                  >
+                    <div
+                      class="image-tile-overlay"
+                      (click)="upload(capture.proofWithThumbnail.proof)"
+                    ></div>
+                    <div class="overlay-icon">
+                      <mat-spinner
+                        *ngIf="
+                          currentUploadingProofHash === capture.hash;
+                          else uploadError
+                        "
+                        diameter="50"
+                      ></mat-spinner>
+                      <ng-template #uploadError>
+                        <mat-icon>error</mat-icon>
+                      </ng-template>
+                    </div>
+                  </mat-grid-tile>
+                </ng-container>
+              </ng-container>
             </mat-grid-list>
           </ng-container>
         </div>

--- a/src/app/pages/home/home.page.scss
+++ b/src/app/pages/home/home.page.scss
@@ -44,6 +44,23 @@ mat-toolbar {
     border-radius: 4px;
     background-position: center center;
     background-size: cover;
+
+    .image-tile-overlay {
+      width: 100%;
+      height: 100%;
+      background-color: white;
+      opacity: 0.7;
+    }
+
+    .overlay-icon {
+      opacity: 1;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      -ms-transform: translate(-50%, -50%);
+      text-align: center;
+    }
   }
 
   app-post-capture-card {

--- a/src/app/pages/home/home.page.scss
+++ b/src/app/pages/home/home.page.scss
@@ -58,8 +58,6 @@ mat-toolbar {
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      -ms-transform: translate(-50%, -50%);
-      text-align: center;
     }
   }
 

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -4,14 +4,7 @@ import { MatTabChangeEvent } from '@angular/material/tabs';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { groupBy } from 'lodash';
 import { combineLatest, defer, interval, of, zip } from 'rxjs';
-import {
-  concatMap,
-  concatMapTo,
-  distinctUntilChanged,
-  first,
-  map,
-  pluck,
-} from 'rxjs/operators';
+import { concatMap, concatMapTo, first, map, pluck } from 'rxjs/operators';
 import { CollectorService } from '../../services/collector/collector.service';
 import { DiaBackendAssetRepository } from '../../services/dia-backend/asset/dia-backend-asset-repository.service';
 import { DiaBackendAuthService } from '../../services/dia-backend/auth/dia-backend-auth.service';
@@ -19,6 +12,7 @@ import { DiaBackendTransactionRepository } from '../../services/dia-backend/tran
 import { IgnoredTransactionRepository } from '../../services/dia-backend/transaction/ignored-transaction-repository.service';
 import { PushNotificationService } from '../../services/push-notification/push-notification.service';
 import { getOldProof } from '../../services/repositories/proof/old-proof-adapter';
+import { Proof } from '../../services/repositories/proof/proof';
 import { ProofRepository } from '../../services/repositories/proof/proof-repository.service';
 import { capture } from '../../utils/camera';
 import { forkJoinWithDefault } from '../../utils/rx-operators';
@@ -47,6 +41,7 @@ export class HomePage implements OnInit {
   inboxCount$ = this.pollingInbox$().pipe(
     map(transactions => transactions.length)
   );
+  currentUploadingProofHash = '';
 
   constructor(
     private readonly proofRepository: ProofRepository,
@@ -78,20 +73,13 @@ export class HomePage implements OnInit {
 
     return combineLatest([originallyOwnedAssets$, proofsWithThumbnail$]).pipe(
       map(([assets, proofsWithThumbnail]) =>
-        assets.map(asset => ({
-          asset,
-          // tslint:disable-next-line: no-non-null-assertion
-          proofWithThumbnail: proofsWithThumbnail.find(
-            p => getOldProof(p.proof).hash === asset.proof_hash
-          )!,
+        proofsWithThumbnail.map(proofWithThumbnail => ({
+          hash: getOldProof(proofWithThumbnail.proof).hash,
+          proofWithThumbnail,
+          asset: assets.find(
+            a => getOldProof(proofWithThumbnail.proof).hash === a.proof_hash
+          ),
         }))
-      ),
-      // WORKAROUND: Use the lax comparison for now. We will redefine the flow
-      // to save and show Proofs first, and then publish to DIA backend. See
-      // #212:
-      // https://github.com/numbersprotocol/capture-lite/issues/212
-      distinctUntilChanged(
-        (captures1, captures2) => captures1.length === captures2.length
       )
     );
   }
@@ -141,6 +129,20 @@ export class HomePage implements OnInit {
         untilDestroyed(this)
       )
       .subscribe();
+  }
+
+  /**
+   * WORKAROUND: use a single string currentUploadingProofHash to display uploading spinner for single Capture
+   * The implementation has a limitation that only 1 Capture could be triggered to upload at a time.
+   */
+  async upload(proof: Proof) {
+    if (this.currentUploadingProofHash) {
+      return;
+    }
+    this.currentUploadingProofHash = getOldProof(proof).hash;
+    return this.diaBackendAssetRepository
+      .add(proof)
+      .finally(() => (this.currentUploadingProofHash = ''));
   }
 
   onTapChanged(event: MatTabChangeEvent) {


### PR DESCRIPTION
## Enhancements

- Change data flow to allow undefined asset so that upload failure doesn't prevent the view from updating.

- Display semi-transparent white overlay and error icon when upload fails. Clicking the overlay triggers re-uploading.

- Display uploading spinner when re-uploading.

## Limitations

- The user can only re-upload 1 photo at a time. During the upload, tapping the other upload-error photos does nothing.

- When uploading the photo in the normal flow, the user would see the upload error first (after the proof is added to the repository but before the asset is added to the repository)

It seems to me that trying to remove these limitations without adding a persistent upload state for Proof would make the component data flow very dirty. Feature-wise I believe the current limitation is acceptable so maybe we could improve it later, but if there's any quick way to improve the implementation or remove the limitations I'd be glad to hear it and make change accordingly.