### PR TITLE
Fix dia backend auth migrate

### DIFF
--- a/src/app/services/dia-backend/auth/dia-backend-auth.service.ts
+++ b/src/app/services/dia-backend/auth/dia-backend-auth.service.ts
@@ -30,7 +30,10 @@ export class DiaBackendAuthService {
       key: 'numbersStoragePublisher_authToken',
     });
     if (oldToken.value) {
-      this.setToken(oldToken.value.split(' ')[1]);
+      const splitted = oldToken.value.split(' ');
+      if (splitted[0] === 'token' && splitted[1]) {
+        this.setToken(splitted[1]);
+      }
     }
 
     const oldUsername = await Storage.get({
@@ -135,7 +138,7 @@ export class DiaBackendAuthService {
   async hasLoggedIn() {
     await this.migrate();
     const token = await this.preferences.getString(PrefKeys.TOKEN);
-    return token !== '';
+    return !!token;
   }
 
   getUsername$() {

--- a/src/app/services/dia-backend/auth/dia-backend-auth.service.ts
+++ b/src/app/services/dia-backend/auth/dia-backend-auth.service.ts
@@ -30,7 +30,7 @@ export class DiaBackendAuthService {
       key: 'numbersStoragePublisher_authToken',
     });
     if (oldToken.value) {
-      this.setToken(oldToken.value);
+      this.setToken(oldToken.value.split(' ')[1]);
     }
   }
 

--- a/src/app/services/dia-backend/auth/dia-backend-auth.service.ts
+++ b/src/app/services/dia-backend/auth/dia-backend-auth.service.ts
@@ -32,6 +32,20 @@ export class DiaBackendAuthService {
     if (oldToken.value) {
       this.setToken(oldToken.value.split(' ')[1]);
     }
+
+    const oldUsername = await Storage.get({
+      key: 'numbersStoragePublisher_userName',
+    });
+    if (oldUsername.value) {
+      this.setUsername(oldUsername.value);
+    }
+
+    const oldEmail = await Storage.get({
+      key: 'numbersStoragePublisher_email',
+    });
+    if (oldEmail.value) {
+      this.setEmail(oldEmail.value);
+    }
   }
 
   initialize$() {

--- a/src/app/services/image-store/image-store.service.ts
+++ b/src/app/services/image-store/image-store.service.ts
@@ -49,24 +49,8 @@ export class ImageStore {
           recursive: true,
         });
       }
-      await this.migrate();
       this.hasInitialized = true;
     });
-  }
-
-  private async migrate() {
-    const dirs = await this.filesystemPlugin.readdir({
-      directory: this.directory,
-      path: '',
-    });
-    if (dirs.files.includes('FileStore')) {
-      await this.filesystemPlugin.copy({
-        directory: this.directory,
-        from: 'FileStore',
-        toDirectory: this.directory,
-        to: ImageStore.name,
-      });
-    }
   }
 
   async read(index: string) {


### PR DESCRIPTION
Completely migrate the `DiaBackendAuthService` from old `NumbersStoragePublisher` class. This migration has been tested on web and Android devices with 0.7.5 to 0.11.4 update. The previous failure is caused by the auth `token` contains `token ` string in the old version but not in the latest one.