### PR TITLE
Change the background-size to cover for capture thumbs.

### DIFF
--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -67,7 +67,7 @@
                 <mat-grid-tile
                   *ngIf="capture.asset"
                   class="square-image-tile"
-                  [style.background]="
+                  [style.backgroundImage]="
                     'url(data:image/*;base64,' +
                     (capture.proofWithThumbnail.thumbnailBase64$ | async)!
                   "
@@ -77,7 +77,7 @@
                 <ng-container *ngIf="!capture.asset">
                   <mat-grid-tile
                     class="square-image-tile"
-                    [style.background]="
+                    [style.backgroundImage]="
                       'url(data:image/*;base64,' +
                       (capture.proofWithThumbnail.thumbnailBase64$ | async)!
                     "

--- a/src/app/pages/home/home.page.scss
+++ b/src/app/pages/home/home.page.scss
@@ -92,3 +92,7 @@ button[mat-fab] {
   bottom: 16px;
   right: 16px;
 }
+
+mat-grid-tile {
+  background-size: cover;
+}


### PR DESCRIPTION
See #331. The repeated thumbnail for captures is fixed by setting the `background-size` CSS property to `cover`. The fix has been tested on web and Exodus 1s.