### PR TITLE
Add extension to the image stored in ImageStore.

### DIFF
--- a/src/app/services/image-store/image-store.service.spec.ts
+++ b/src/app/services/image-store/image-store.service.spec.ts
@@ -33,17 +33,17 @@ describe('ImageStore', () => {
   });
 
   it('should write file with Base64', async () => {
-    const index = await store.write(sampleFile);
+    const index = await store.write(sampleFile, sampleMimeType);
     expect(await store.exists(index)).toBeTrue();
   });
 
   it('should read file with index', async () => {
-    const index = await store.write(sampleFile);
+    const index = await store.write(sampleFile, sampleMimeType);
     expect(await store.read(index)).toEqual(sampleFile);
   });
 
   it('should delete file with index', async () => {
-    const index = await store.write(sampleFile);
+    const index = await store.write(sampleFile, sampleMimeType);
 
     await store.delete(index);
 
@@ -51,7 +51,7 @@ describe('ImageStore', () => {
   });
 
   it('should delete file with index and thumbnail', async () => {
-    const index = await store.write(sampleFile);
+    const index = await store.write(sampleFile, sampleMimeType);
     await store.readThumbnail(index, sampleMimeType);
 
     await store.delete(index);
@@ -60,10 +60,10 @@ describe('ImageStore', () => {
   });
 
   it('should remove all files after drop', async () => {
-    const index1 = await store.write(sampleFile);
+    const index1 = await store.write(sampleFile, sampleMimeType);
     const anotherFile =
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAAAXRSTlPM0jRW/QAAAApJREFUeJxjYgAAAAYAAzY3fKgAAAAASUVORK5CYII=';
-    const index2 = await store.write(anotherFile);
+    const index2 = await store.write(anotherFile, sampleMimeType);
 
     await store.drop();
 
@@ -77,7 +77,9 @@ describe('ImageStore', () => {
       stringToBase64(`${value}`)
     );
 
-    const indexes = await Promise.all(files.map(file => store.write(file)));
+    const indexes = await Promise.all(
+      files.map(file => store.write(file, sampleMimeType))
+    );
 
     for (const index of indexes) {
       expect(await store.exists(index)).toBeTrue();
@@ -92,7 +94,7 @@ describe('ImageStore', () => {
     const indexes = [];
 
     for (const file of files) {
-      indexes.push(await store.write(file));
+      indexes.push(await store.write(file, sampleMimeType));
     }
 
     await Promise.all(indexes.map(index => store.delete(index)));
@@ -103,7 +105,7 @@ describe('ImageStore', () => {
   });
 
   it('should read thumbnail', async () => {
-    const index = await store.write(sampleFile);
+    const index = await store.write(sampleFile, sampleMimeType);
     const thumbnailFile = await store.readThumbnail(index, sampleMimeType);
     expect(thumbnailFile).toBeTruthy();
   });

--- a/src/app/services/image-store/image-store.service.ts
+++ b/src/app/services/image-store/image-store.service.ts
@@ -5,7 +5,7 @@ import ImageBlobReduce from 'image-blob-reduce';
 import { FILESYSTEM_PLUGIN } from '../../shared/capacitor-plugins/capacitor-plugins.module';
 import { sha256WithBase64 } from '../../utils/crypto/crypto';
 import { base64ToBlob, blobToBase64 } from '../../utils/encoding/encoding';
-import { getExtension, MimeType } from '../../utils/mime-type';
+import { MimeType, toExtension } from '../../utils/mime-type';
 import { Database } from '../database/database.service';
 import { OnConflictStrategy, Tuple } from '../database/table/table';
 
@@ -162,7 +162,7 @@ export class ImageStore {
   private async setImageExtension(index: string, mimeType: MimeType) {
     return (
       await this.extensionTable.insert(
-        [{ imageIndex: index, extension: getExtension(mimeType) }],
+        [{ imageIndex: index, extension: toExtension(mimeType) }],
         OnConflictStrategy.IGNORE
       )
     )[0];

--- a/src/app/services/repositories/proof/proof.ts
+++ b/src/app/services/repositories/proof/proof.ts
@@ -38,7 +38,7 @@ export class Proof {
   private async setAssets(assets: Assets) {
     const indexedAssetEntries: [string, AssetMeta][] = [];
     for (const [base64, meta] of Object.entries(assets)) {
-      const index = await this.imageStore.write(base64);
+      const index = await this.imageStore.write(base64, meta.mimeType);
       indexedAssetEntries.push([index, meta]);
     }
 

--- a/src/app/utils/mime-type.ts
+++ b/src/app/utils/mime-type.ts
@@ -2,7 +2,7 @@
 // other platform.
 export type MimeType = 'image/jpeg' | 'image/png' | 'application/octet-stream';
 
-export function getExtension(mimeType: MimeType) {
+export function toExtension(mimeType: MimeType) {
   switch (mimeType) {
     case 'image/jpeg':
       return 'jpg';

--- a/src/app/utils/mime-type.ts
+++ b/src/app/utils/mime-type.ts
@@ -8,6 +8,10 @@ export function getExtension(mimeType: MimeType) {
       return 'jpg';
     case 'image/png':
       return 'png';
+    case 'application/octet-stream':
+      return 'bin';
+    default:
+      throw TypeError(`Unknown MIME type: ${mimeType}`);
   }
 }
 
@@ -18,6 +22,8 @@ export function fromExtension(extension: string): MimeType {
       return 'image/jpeg';
     case 'png':
       return 'image/png';
+    case 'bin':
+      return 'application/octet-stream';
     default:
       throw TypeError(`Unknown extension: ${extension}`);
   }


### PR DESCRIPTION
Add file extension to the images stored in `ImageStore` in order to successfully share files with Capacitor `Share` plugin. We do not need to migrate the data if we merge this PR in next release.