### PR TITLE
Fix iOS DIA backend delete error

### DIFF
--- a/src/app/services/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/services/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -215,7 +215,7 @@ export class DiaBackendAssetRepository {
     }).pipe(
       concatMap(headers =>
         this.httpClient.delete<DeleteAssetResponse>(
-          `${BASE_URL}/api/v2/assets/${asset.id}`,
+          `${BASE_URL}/api/v2/assets/${asset.id}/`,
           { headers }
         )
       )


### PR DESCRIPTION
Append slash in delete asset API endpoint to prevent iOS webview dropping auth header when HTTP redirection.