### PR TITLE
WORKAROUND: Fix Unable to Send PostCaptures

### DIFF
--- a/src/app/pages/home/asset/asset.page.ts
+++ b/src/app/pages/home/asset/asset.page.ts
@@ -9,7 +9,7 @@ import {
   concatMap,
   first,
   map,
-  share,
+  shareReplay,
   switchMap,
   switchMapTo,
   tap,
@@ -40,7 +40,7 @@ export class AssetPage {
     isNonNullable(),
     switchMap(id => this.diaBackendAssetRepository.getById$(id)),
     isNonNullable(),
-    share()
+    shareReplay({ bufferSize: 1, refCount: true })
   );
   readonly location$ = this.asset$.pipe(
     map(asset => {

--- a/src/app/pages/home/asset/asset.page.ts
+++ b/src/app/pages/home/asset/asset.page.ts
@@ -7,6 +7,7 @@ import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { defer, zip } from 'rxjs';
 import {
   concatMap,
+  concatMapTo,
   first,
   map,
   shareReplay,
@@ -110,7 +111,12 @@ export class AssetPage {
         if (proof) {
           this.proofRepositroy.remove(proof);
         }
-        return this.diaBackendAssetRepository.remove$(asset).pipe(first());
+        return this.diaBackendAssetRepository
+          .remove$(asset)
+          .pipe(
+            first(),
+            concatMapTo(defer(() => this.diaBackendAssetRepository.refresh$()))
+          );
       }),
       switchMapTo(defer(() => this.router.navigate(['..'])))
     );

--- a/src/app/pages/home/asset/information/information.page.ts
+++ b/src/app/pages/home/asset/information/information.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy } from '@ngneat/until-destroy';
-import { map, share, switchMap } from 'rxjs/operators';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { DiaBackendAssetRepository } from '../../../../services/dia-backend/asset/dia-backend-asset-repository.service';
 import { isNonNullable } from '../../../../utils/rx-operators/rx-operators';
 
@@ -17,7 +17,7 @@ export class InformationPage {
     isNonNullable(),
     switchMap(id => this.diaBackendAssetRepository.getById$(id)),
     isNonNullable(),
-    share()
+    shareReplay({ bufferSize: 1, refCount: true })
   );
 
   constructor(

--- a/src/app/pages/home/asset/sending-post-capture/sending-post-capture.page.ts
+++ b/src/app/pages/home/asset/sending-post-capture/sending-post-capture.page.ts
@@ -8,7 +8,7 @@ import {
   concatMapTo,
   first,
   map,
-  share,
+  shareReplay,
   switchMap,
 } from 'rxjs/operators';
 import { BlockingActionService } from '../../../../services/blocking-action/blocking-action.service';
@@ -37,7 +37,7 @@ export class SendingPostCapturePage {
     isNonNullable(),
     switchMap(id => this.diaBackendAssetRepository.getById$(id)),
     isNonNullable(),
-    share()
+    shareReplay({ bufferSize: 1, refCount: true })
   );
   readonly contact$ = this.route.paramMap.pipe(
     map(params => params.get('contact')),
@@ -102,7 +102,9 @@ export class SendingPostCapturePage {
         if (proof) {
           await this.proofRepository.remove(proof);
         }
-      })
+      }),
+      concatMapTo(this.diaBackendAssetRepository.refresh$()),
+      concatMapTo(this.diaBackendAssetRepository.removeCache$(asset))
     );
   }
 }

--- a/src/app/pages/home/inbox/inbox.page.ts
+++ b/src/app/pages/home/inbox/inbox.page.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { first, share, switchMapTo } from 'rxjs/operators';
+import { first, shareReplay, switchMapTo } from 'rxjs/operators';
 import { BlockingActionService } from '../../../services/blocking-action/blocking-action.service';
 import { DiaBackendTransactionRepository } from '../../../services/dia-backend/transaction/dia-backend-transaction-repository.service';
 import { IgnoredTransactionRepository } from '../../../services/dia-backend/transaction/ignored-transaction-repository.service';
@@ -14,7 +14,7 @@ import { IgnoredTransactionRepository } from '../../../services/dia-backend/tran
 export class InboxPage {
   readonly receivedTransactions$ = this.diaBackendTransactionRepository
     .getInbox$()
-    .pipe(share());
+    .pipe(shareReplay({ bufferSize: 1, refCount: true }));
   readonly isFetching$ = this.diaBackendTransactionRepository.isFetching$();
 
   constructor(

--- a/src/app/pages/home/transaction/transaction-details/transaction-details.page.ts
+++ b/src/app/pages/home/transaction/transaction-details/transaction-details.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { UntilDestroy } from '@ngneat/until-destroy';
-import { map, share, switchMap } from 'rxjs/operators';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { DiaBackendAuthService } from '../../../../services/dia-backend/auth/dia-backend-auth.service';
 import {
   DiaBackendTransaction,
@@ -20,7 +20,7 @@ export class TransactionDetailsPage {
     isNonNullable(),
     switchMap(id => this.diaBackendTransactionRepository.getById$(id)),
     isNonNullable(),
-    share()
+    shareReplay({ bufferSize: 1, refCount: true })
   );
   readonly status$ = this.transaction$.pipe(
     switchMap(transaction =>

--- a/src/app/pages/home/transaction/transaction.page.ts
+++ b/src/app/pages/home/transaction/transaction.page.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
-import { map, share } from 'rxjs/operators';
+import { map, shareReplay } from 'rxjs/operators';
 import { DiaBackendAuthService } from '../../../services/dia-backend/auth/dia-backend-auth.service';
 import { DiaBackendTransactionRepository } from '../../../services/dia-backend/transaction/dia-backend-transaction-repository.service';
 import { getStatus } from './transaction-details/transaction-details.page';
@@ -21,7 +21,7 @@ export class TransactionPage {
           status: getStatus(transaction, this.diaBackendAuthService.getEmail()),
         }))
       ),
-      share()
+      shareReplay({ bufferSize: 1, refCount: true })
     );
   readonly isFetching$ = this.diaBackendTransactionRepository.isFetching$();
 

--- a/src/app/services/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/services/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -15,7 +15,7 @@ import {
 } from 'rxjs/operators';
 import { base64ToBlob } from '../../../utils/encoding/encoding';
 import { toExtension } from '../../../utils/mime-type';
-import { switchTap } from '../../../utils/rx-operators/rx-operators';
+import { switchTap, VOID$ } from '../../../utils/rx-operators/rx-operators';
 import { Database } from '../../database/database.service';
 import { OnConflictStrategy, Tuple } from '../../database/table/table';
 import { NotificationService } from '../../notification/notification.service';
@@ -124,6 +124,12 @@ export class DiaBackendAssetRepository {
           { headers }
         )
       )
+    );
+  }
+
+  removeCache$(asset: DiaBackendAsset) {
+    return defer(() => this.fetchAllCacheTable.delete([asset])).pipe(
+      catchError(() => VOID$)
     );
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -114,7 +114,6 @@
     "rxjs-no-internal": true,
     "rxjs-no-nested-subscribe": true,
     "rxjs-no-redundant-notify": true,
-    "rxjs-no-sharereplay": true,
     "rxjs-no-subclass": true,
     "rxjs-no-unbound-methods": true,
     "rxjs-no-unsafe-catch": true,


### PR DESCRIPTION
Introduce yet another workaround for clear the unsynced catch regarding PostCapture deletion. Also, use `shareReplay({bufferSize: 1, refCount: true})` to replace `share()` to avoid the shared `Observable` from not emitting on subscribe.