### PR TITLE
Rebuild Capture - Step E2 (Customized Geolocation Cache Policy)

### DIFF
--- a/src/app/shared/services/geolocation/geolocation.service.spec.ts
+++ b/src/app/shared/services/geolocation/geolocation.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+import { SharedTestingModule } from '../../shared-testing.module';
+import { GeolocationService } from './geolocation.service';
+
+describe('GeolocationService', () => {
+  let service: GeolocationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [SharedTestingModule] });
+    service = TestBed.inject(GeolocationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/geolocation/geolocation.service.ts
+++ b/src/app/shared/services/geolocation/geolocation.service.ts
@@ -1,0 +1,95 @@
+import { Inject, Injectable } from '@angular/core';
+import { GeolocationPlugin } from '@capacitor/core';
+import { GEOLOCATION_PLUGIN } from '../../core/capacitor-plugins/capacitor-plugins.module';
+
+// As most of the geolocation plugins are buggy due to the rapid-updating nature
+// of the related APIs in native platforms, wrap the plugin as an adapter.
+@Injectable({
+  providedIn: 'root',
+})
+export class GeolocationService {
+  // Cache the current position manually due to the issue of Capacitor
+  // geolocation plugin: https://github.com/ionic-team/capacitor/issues/3304
+  private currentPositionCache?: Position;
+
+  constructor(
+    @Inject(GEOLOCATION_PLUGIN)
+    private readonly geolocationPlugin: GeolocationPlugin
+  ) {}
+
+  async getCurrentPosition(
+    { enableHighAccuracy, timeout, maximumAge }: GetCurrentPositionOptions = {
+      enableHighAccuracy: true,
+      timeout: undefined,
+      maximumAge: undefined,
+    }
+  ): Promise<Position | undefined> {
+    if (
+      maximumAge &&
+      maximumAge > 0 &&
+      this.currentPositionCache &&
+      Date.now() - this.currentPositionCache.timestamp < maximumAge
+    ) {
+      return this.currentPositionCache;
+    }
+
+    const result =
+      timeout && timeout > 0
+        ? await Promise.race([
+            this.geolocationPlugin.getCurrentPosition({
+              enableHighAccuracy,
+              timeout,
+              maximumAge,
+            }),
+            // Set timeout manually to avoid location never resolved:
+            // https://github.com/ionic-team/capacitor/issues/3062
+            getTimer(timeout),
+          ])
+        : await this.geolocationPlugin.getCurrentPosition({
+            enableHighAccuracy,
+            timeout,
+            maximumAge,
+          });
+
+    if (result) {
+      this.currentPositionCache = result;
+    }
+
+    return result;
+  }
+}
+
+async function getTimer(timeout: number) {
+  return new Promise<undefined>((_, reject) => {
+    setTimeout(() => {
+      reject(new GeolocationError(GeolocationErrorCode.TIMEOUT));
+    }, timeout);
+  });
+}
+
+export interface GetCurrentPositionOptions {
+  readonly enableHighAccuracy?: boolean;
+  readonly timeout?: number;
+  readonly maximumAge?: number;
+}
+
+export interface Position {
+  readonly timestamp: number;
+  readonly coords: Coordinates;
+}
+
+interface Coordinates {
+  readonly latitude: number;
+  readonly longitude: number;
+}
+
+export class GeolocationError {
+  constructor(readonly code: GeolocationErrorCode, readonly message?: string) {}
+}
+
+export const enum GeolocationErrorCode {
+  NOT_USED,
+  PERMISSION_DENIED,
+  POSITION_UNAVAILABLE,
+  TIMEOUT,
+}


### PR DESCRIPTION
- Implement the customized geolocation cache policy. See the latest details on miro.
- Change interface `GeolocationPositionError` to class `GeolocationError` to use `instanceof` to check the error type safely.
![Screenshot from 2021-01-15 11-54-49](https://user-images.githubusercontent.com/14951000/104679381-81a03280-5728-11eb-9a7d-3ea631086da9.png)
