### PR TITLE
Rebuild Capture - E3 (Show Spinner on Loading Captures)

### DIFF
--- a/src/app/features/home/capture-tab/capture-tab.component.html
+++ b/src/app/features/home/capture-tab/capture-tab.component.html
@@ -1,3 +1,9 @@
+<div
+  *ngIf="(capturesByDate$ | async) === null"
+  class="loading-spinner-container"
+>
+  <ion-spinner></ion-spinner>
+</div>
 <ng-container
   *ngFor="
     let group of capturesByDate$ | async | keyvalue: keyDescendingOrder;
@@ -15,7 +21,10 @@
       "
       class="capture-item"
     >
-      <div *ngIf="captureItem.isCollecting" class="spinner-container">
+      <div
+        *ngIf="captureItem.isCollecting"
+        class="collecting-spinner-container"
+      >
         <ion-spinner></ion-spinner>
       </div>
       <ion-icon

--- a/src/app/features/home/capture-tab/capture-tab.component.scss
+++ b/src/app/features/home/capture-tab/capture-tab.component.scss
@@ -5,6 +5,11 @@
   margin-bottom: 128px;
 }
 
+.loading-spinner-container {
+  width: fit-content;
+  margin: 32px auto;
+}
+
 div.mat-title {
   margin: 26px 0 0;
   font-size: large;
@@ -16,7 +21,7 @@ div.mat-title {
   object-fit: cover;
   border-radius: 4px;
 
-  .spinner-container {
+  .collecting-spinner-container {
     position: absolute;
     top: 50%;
     left: 50%;

--- a/src/app/shared/services/database/table/capacitor-filesystem-table/capacitor-filesystem-table.spec.ts
+++ b/src/app/shared/services/database/table/capacitor-filesystem-table/capacitor-filesystem-table.spec.ts
@@ -17,7 +17,7 @@ describe('CapacitorFilesystemTable', () => {
   it('should be created', () => expect(table).toBeTruthy());
 
   it('should emit empty array with Observable on initial query', done => {
-    table.queryAll$().subscribe(tuples => {
+    table.queryAll$.subscribe(tuples => {
       expect(tuples).toEqual([]);
       done();
     });
@@ -32,7 +32,7 @@ describe('CapacitorFilesystemTable', () => {
     await table.insert([TUPLE1]);
     await table.insert([TUPLE2]);
 
-    table.queryAll$().subscribe(tuples => {
+    table.queryAll$.subscribe(tuples => {
       expect(tuples).toEqual([TUPLE1, TUPLE2]);
       done();
     });
@@ -130,7 +130,7 @@ describe('CapacitorFilesystemTable', () => {
     await table.insert([TUPLE1]);
     await table.delete([sameTuple]);
 
-    table.queryAll$().subscribe(tuples => {
+    table.queryAll$.subscribe(tuples => {
       expect(tuples).toEqual([]);
       done();
     });
@@ -142,7 +142,7 @@ describe('CapacitorFilesystemTable', () => {
     await table.insert([TUPLE1, TUPLE2]);
     await table.delete([sameTuple1]);
 
-    table.queryAll$().subscribe(tuples => {
+    table.queryAll$.subscribe(tuples => {
       expect(tuples).toEqual([TUPLE2]);
       done();
     });
@@ -154,7 +154,7 @@ describe('CapacitorFilesystemTable', () => {
     await table.insert([TUPLE1, TUPLE2]);
     await table.delete([sameIdTuple1], (x, y) => x.id === y.id);
 
-    table.queryAll$().subscribe(tuples => {
+    table.queryAll$.subscribe(tuples => {
       expect(tuples).toEqual([TUPLE2]);
       done();
     });
@@ -184,7 +184,7 @@ describe('CapacitorFilesystemTable', () => {
 
     await Promise.all(expectedTuples.map(tuple => table.insert([tuple])));
 
-    table.queryAll$().subscribe(tuples => {
+    table.queryAll$.subscribe(tuples => {
       expect(tuples).toEqual(expectedTuples);
       done();
     });
@@ -206,7 +206,7 @@ describe('CapacitorFilesystemTable', () => {
 
     await Promise.all(sourceTuple.map(tuple => table.delete([tuple])));
 
-    table.queryAll$().subscribe(tuples => {
+    table.queryAll$.subscribe(tuples => {
       expect(tuples).toEqual([]);
       done();
     });
@@ -218,7 +218,7 @@ describe('CapacitorFilesystemTable', () => {
 
     await table.update(sameIdTuple1, (x, y) => x.id === y.id);
 
-    table.queryAll$().subscribe(tuples => {
+    table.queryAll$.subscribe(tuples => {
       expect(tuples).toEqual([sameIdTuple1]);
       done();
     });

--- a/src/app/shared/services/database/table/table.ts
+++ b/src/app/shared/services/database/table/table.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs';
 
 export interface Table<T extends Tuple> {
   readonly id: string;
-  queryAll$(): Observable<T[]>;
+  readonly queryAll$: Observable<T[]>;
   queryAll(): Promise<T[]>;
   insert(
     tuples: T[],

--- a/src/app/shared/services/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/shared/services/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -98,10 +98,14 @@ export class DiaBackendAssetRepository {
   }
 
   remove$(asset: DiaBackendAsset) {
+    return this.removeById$(asset.id);
+  }
+
+  removeById$(id: string) {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers =>
         this.httpClient.delete<DeleteAssetResponse>(
-          `${BASE_URL}/api/v2/assets/${asset.id}/`,
+          `${BASE_URL}/api/v2/assets/${id}/`,
           { headers }
         )
       )

--- a/src/app/shared/services/dia-backend/transaction/ignored-transaction-repository.service.ts
+++ b/src/app/shared/services/dia-backend/transaction/ignored-transaction-repository.service.ts
@@ -16,7 +16,7 @@ export class IgnoredTransactionRepository {
   constructor(private readonly database: Database) {}
 
   getAll$(): Observable<string[]> {
-    return this.table.queryAll$().pipe(
+    return this.table.queryAll$.pipe(
       map(tuples => tuples.map(tuple => tuple.id)),
       distinctUntilChanged(isEqual)
     );

--- a/src/app/shared/services/repositories/proof/proof-repository.service.ts
+++ b/src/app/shared/services/repositories/proof/proof-repository.service.ts
@@ -20,7 +20,7 @@ export class ProofRepository {
   ) {}
 
   getAll$() {
-    return this.table.queryAll$().pipe(
+    return this.table.queryAll$.pipe(
       distinctUntilChanged(isEqual),
       map((indexedProofViews: IndexedProofView[]) => {
         return indexedProofViews.map(view =>


### PR DESCRIPTION
- Merge E1 into rebuild-capture branch.
- Show a spinner when loading captures on capture tab.
- Use `undefined` as the initial value of `Database.Table.tuple$` and make `queryAll$` emit value if `isNonNullable`.