### PR TITLE
Determine pre-fetching by remote asset count

### DIFF
--- a/src/app/features/home/home.page.ts
+++ b/src/app/features/home/home.page.ts
@@ -8,6 +8,7 @@ import { defer, of } from 'rxjs';
 import { concatMap, map, tap } from 'rxjs/operators';
 import { CaptureService } from '../../shared/services/capture/capture.service';
 import { ConfirmAlert } from '../../shared/services/confirm-alert/confirm-alert.service';
+import { DiaBackendAssetRepository } from '../../shared/services/dia-backend/asset/dia-backend-asset-repository.service';
 import { DiaBackendAuthService } from '../../shared/services/dia-backend/auth/dia-backend-auth.service';
 import { DiaBackendTransactionRepository } from '../../shared/services/dia-backend/transaction/dia-backend-transaction-repository.service';
 import { MigrationService } from '../../shared/services/migration/migration.service';
@@ -33,6 +34,7 @@ export class HomePage {
   constructor(
     private readonly changeDetectorRef: ChangeDetectorRef,
     private readonly diaBackendAuthService: DiaBackendAuthService,
+    private readonly diaBackendAssetRepository: DiaBackendAssetRepository,
     private readonly diaBackendTransactionRepository: DiaBackendTransactionRepository,
     private readonly onboardingService: OnboardingService,
     private readonly router: Router,
@@ -67,13 +69,12 @@ export class HomePage {
         relativeTo: this.route,
       });
     }
-    if (!(await this.onboardingService.hasPrefetchedDiaBackendAssets())) {
+    if ((await this.diaBackendAssetRepository.getCount()) > 0) {
       if (await this.showPrefetchAlert()) {
         return this.dialog.open(PrefetchingDialogComponent, {
           disableClose: true,
         });
       }
-      return this.onboardingService.setHasPrefetchedDiaBackendAssets(true);
     }
   }
 

--- a/src/app/features/home/onboarding/prefetching-dialog/prefetching-dialog.component.ts
+++ b/src/app/features/home/onboarding/prefetching-dialog/prefetching-dialog.component.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { DiaBackendAssetPrefetchingService } from '../../../../shared/services/dia-backend/asset/prefetching/dia-backend-asset-prefetching.service';
-import { OnboardingService } from '../../../../shared/services/onboarding/onboarding.service';
 
 @Component({
   selector: 'app-prefetching-dialog',
@@ -13,8 +12,7 @@ export class PrefetchingDialogComponent {
 
   constructor(
     private readonly dialogRef: MatDialogRef<PrefetchingDialogComponent>,
-    private readonly diaBackendAssetPrefetchingService: DiaBackendAssetPrefetchingService,
-    private readonly onboardingService: OnboardingService
+    private readonly diaBackendAssetPrefetchingService: DiaBackendAssetPrefetchingService
   ) {
     this.prefetch();
   }
@@ -23,7 +21,6 @@ export class PrefetchingDialogComponent {
     await this.diaBackendAssetPrefetchingService.prefetch(
       (currentCount, totalCount) => (this.progress = currentCount / totalCount)
     );
-    await this.onboardingService.setHasPrefetchedDiaBackendAssets(true);
     this.dialogRef.close();
   }
 }

--- a/src/app/shared/services/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/shared/services/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -5,7 +5,9 @@ import {
   concatMap,
   concatMapTo,
   distinctUntilChanged,
+  first,
   map,
+  pluck,
   tap,
 } from 'rxjs/operators';
 import { base64ToBlob } from '../../../../utils/encoding/encoding';
@@ -37,6 +39,21 @@ export class DiaBackendAssetRepository {
     private readonly httpClient: HttpClient,
     private readonly authService: DiaBackendAuthService
   ) {}
+
+  async getCount() {
+    return this.authService.getAuthHeaders$
+      .pipe(
+        concatMap(headers =>
+          this.httpClient.get<PaginatedResponse<DiaBackendAsset>>(
+            `${BASE_URL}/api/v2/assets/`,
+            { headers }
+          )
+        ),
+        pluck('count'),
+        first()
+      )
+      .toPromise();
+  }
 
   fetchById$(id: string) {
     return this.authService.getAuthHeaders$.pipe(

--- a/src/app/shared/services/onboarding/onboarding.service.ts
+++ b/src/app/shared/services/onboarding/onboarding.service.ts
@@ -19,23 +19,8 @@ export class OnboardingService {
   async onboard() {
     return this.preferences.setBoolean(PrefKeys.IS_ONBOARDING, false);
   }
-
-  async hasPrefetchedDiaBackendAssets() {
-    return this.preferences.getBoolean(
-      PrefKeys.HAS_PREFETCHED_DIA_BACKEND_ASSETS,
-      false
-    );
-  }
-
-  async setHasPrefetchedDiaBackendAssets(value: boolean) {
-    return this.preferences.setBoolean(
-      PrefKeys.HAS_PREFETCHED_DIA_BACKEND_ASSETS,
-      value
-    );
-  }
 }
 
 const enum PrefKeys {
   IS_ONBOARDING = 'IS_ONBOARDING',
-  HAS_PREFETCHED_DIA_BACKEND_ASSETS = 'HAS_PREFETCHED_DIA_BACKEND_ASSETS',
 }


### PR DESCRIPTION
- Pre-fetching is only invoked when newly logged in, so storing a isPrefetched preference is no longer needed. It is replaced by checking the remote asset count which also prevents asking a new user to confirm pre-fetching.