### PR TITLE
Fix onboarding flow

### DIFF
--- a/src/app/features/home/home.page.ts
+++ b/src/app/features/home/home.page.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { TranslocoService } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { defer, of } from 'rxjs';
-import { concatMap, map, tap } from 'rxjs/operators';
+import { catchError, concatMap, map, tap } from 'rxjs/operators';
 import { CaptureService } from '../../shared/services/capture/capture.service';
 import { ConfirmAlert } from '../../shared/services/confirm-alert/confirm-alert.service';
 import { DiaBackendAssetRepository } from '../../shared/services/dia-backend/asset/dia-backend-asset-repository.service';
@@ -13,7 +13,7 @@ import { DiaBackendAuthService } from '../../shared/services/dia-backend/auth/di
 import { DiaBackendTransactionRepository } from '../../shared/services/dia-backend/transaction/dia-backend-transaction-repository.service';
 import { MigrationService } from '../../shared/services/migration/migration.service';
 import { OnboardingService } from '../../shared/services/onboarding/onboarding.service';
-import { switchTapTo } from '../../utils/rx-operators/rx-operators';
+import { switchTapTo, VOID$ } from '../../utils/rx-operators/rx-operators';
 import { PrefetchingDialogComponent } from './onboarding/prefetching-dialog/prefetching-dialog.component';
 
 @UntilDestroy({ checkProperties: true })
@@ -50,6 +50,7 @@ export class HomePage {
     of(this.onboardingService.isNewLogin)
       .pipe(
         concatMap(isNewLogin => this.migrationService.migrate$(isNewLogin)),
+        catchError(() => VOID$),
         switchTapTo(defer(() => this.onboardingRedirect())),
         untilDestroyed(this)
       )

--- a/src/app/features/home/onboarding/prefetching-dialog/prefetching-dialog.component.ts
+++ b/src/app/features/home/onboarding/prefetching-dialog/prefetching-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { MatDialogRef } from '@angular/material/dialog';
 import { DiaBackendAssetPrefetchingService } from '../../../../shared/services/dia-backend/asset/prefetching/dia-backend-asset-prefetching.service';
+import { OnboardingService } from '../../../../shared/services/onboarding/onboarding.service';
 
 @Component({
   selector: 'app-prefetching-dialog',
@@ -12,7 +13,8 @@ export class PrefetchingDialogComponent {
 
   constructor(
     private readonly dialogRef: MatDialogRef<PrefetchingDialogComponent>,
-    private readonly diaBackendAssetPrefetchingService: DiaBackendAssetPrefetchingService
+    private readonly diaBackendAssetPrefetchingService: DiaBackendAssetPrefetchingService,
+    private readonly onboardingService: OnboardingService
   ) {
     this.prefetch();
   }
@@ -21,6 +23,7 @@ export class PrefetchingDialogComponent {
     await this.diaBackendAssetPrefetchingService.prefetch(
       (currentCount, totalCount) => (this.progress = currentCount / totalCount)
     );
+    await this.onboardingService.setHasPrefetchedDiaBackendAssets(true);
     this.dialogRef.close();
   }
 }

--- a/src/app/shared/services/migration/migration.service.ts
+++ b/src/app/shared/services/migration/migration.service.ts
@@ -3,7 +3,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { Plugins } from '@capacitor/core';
 import { BehaviorSubject, defer } from 'rxjs';
 import { concatMap, distinctUntilChanged, tap } from 'rxjs/operators';
-import { switchTapTo, VOID$ } from '../../../utils/rx-operators/rx-operators';
+import { VOID$ } from '../../../utils/rx-operators/rx-operators';
 import { MigratingDialogComponent } from '../../core/migrating-dialog/migrating-dialog.component';
 import {
   DiaBackendAsset,
@@ -41,12 +41,7 @@ export class MigrationService {
       this.runMigrateWithProgressDialog(skip)
     ).pipe(
       concatMap(() => this.preferences.setBoolean(PrefKeys.TO_0_15_0, true)),
-      concatMap(() => this.updatePreviousVersion()),
-      switchTapTo(
-        defer(() =>
-          this.onboardingService.setHasPrefetchedDiaBackendAssets(true)
-        )
-      )
+      concatMap(() => this.updatePreviousVersion())
     );
     return defer(() =>
       this.preferences.getBoolean(PrefKeys.TO_0_15_0, false)
@@ -65,7 +60,9 @@ export class MigrationService {
       data: { progress: 0 },
     });
 
-    return this.to0_15_0().then(() => dialogRef.close());
+    await this.to0_15_0();
+    await this.onboardingService.setHasPrefetchedDiaBackendAssets(true);
+    dialogRef.close();
   }
 
   async updatePreviousVersion() {

--- a/src/app/shared/services/onboarding/onboarding.service.ts
+++ b/src/app/shared/services/onboarding/onboarding.service.ts
@@ -19,8 +19,23 @@ export class OnboardingService {
   async onboard() {
     return this.preferences.setBoolean(PrefKeys.IS_ONBOARDING, false);
   }
+
+  async hasPrefetchedDiaBackendAssets() {
+    return this.preferences.getBoolean(
+      PrefKeys.HAS_PREFETCHED_DIA_BACKEND_ASSETS,
+      false
+    );
+  }
+
+  async setHasPrefetchedDiaBackendAssets(value: boolean) {
+    return this.preferences.setBoolean(
+      PrefKeys.HAS_PREFETCHED_DIA_BACKEND_ASSETS,
+      value
+    );
+  }
 }
 
 const enum PrefKeys {
   IS_ONBOARDING = 'IS_ONBOARDING',
+  HAS_PREFETCHED_DIA_BACKEND_ASSETS = 'HAS_PREFETCHED_DIA_BACKEND_ASSETS',
 }


### PR DESCRIPTION
- Remove `isNewLogin` condition wrapping `redirectOnboarding()` on home page.
- Set `isNewLogin` to `false` before checking if to prefetch dialog.
- Set `hasPrefetchedDiaBackendAssets` to `true` after migration.