### PR TITLE
Set prefetched preference before start migration

### DIFF
--- a/src/app/shared/services/migration/migration.service.ts
+++ b/src/app/shared/services/migration/migration.service.ts
@@ -38,8 +38,9 @@ export class MigrationService {
 
   migrate$(skip?: boolean) {
     const runMigrate$ = defer(() =>
-      this.runMigrateWithProgressDialog(skip)
+      this.onboardingService.setHasPrefetchedDiaBackendAssets(true)
     ).pipe(
+      concatMap(() => this.runMigrateWithProgressDialog(skip)),
       concatMap(() => this.preferences.setBoolean(PrefKeys.TO_0_15_0, true)),
       concatMap(() => this.updatePreviousVersion())
     );
@@ -61,7 +62,6 @@ export class MigrationService {
     });
 
     await this.to0_15_0();
-    await this.onboardingService.setHasPrefetchedDiaBackendAssets(true);
     dialogRef.close();
   }
 


### PR DESCRIPTION
Migration is subject to failures (e.g. httpError), and error out during
migration causes the prefetch preference not set when it should be set.
Move it before starting migration so that it is always set first when
starting the migration that might fails during the process.

Signed-off-by: James Chien <shc261392@gmail.com>