### PR TITLE
Fix migrating set has prefetch corner case

### DIFF
--- a/src/app/features/home/onboarding/prefetching-dialog/prefetching-dialog.component.ts
+++ b/src/app/features/home/onboarding/prefetching-dialog/prefetching-dialog.component.ts
@@ -20,9 +20,15 @@ export class PrefetchingDialogComponent {
   }
 
   private async prefetch() {
-    await this.diaBackendAssetPrefetchingService.prefetch(
-      (currentCount, totalCount) => (this.progress = currentCount / totalCount)
-    );
+    await this.diaBackendAssetPrefetchingService
+      .prefetch(
+        (currentCount, totalCount) =>
+          (this.progress = currentCount / totalCount)
+      )
+      .catch(err => {
+        this.dialogRef.close();
+        throw err;
+      });
     await this.onboardingService.setHasPrefetchedDiaBackendAssets(true);
     this.dialogRef.close();
   }

--- a/src/app/features/home/onboarding/prefetching-dialog/prefetching-dialog.component.ts
+++ b/src/app/features/home/onboarding/prefetching-dialog/prefetching-dialog.component.ts
@@ -20,16 +20,14 @@ export class PrefetchingDialogComponent {
   }
 
   private async prefetch() {
-    await this.diaBackendAssetPrefetchingService
-      .prefetch(
+    try {
+      await this.diaBackendAssetPrefetchingService.prefetch(
         (currentCount, totalCount) =>
           (this.progress = currentCount / totalCount)
-      )
-      .catch(err => {
-        this.dialogRef.close();
-        throw err;
-      });
-    await this.onboardingService.setHasPrefetchedDiaBackendAssets(true);
-    this.dialogRef.close();
+      );
+      await this.onboardingService.setHasPrefetchedDiaBackendAssets(true);
+    } finally {
+      this.dialogRef.close();
+    }
   }
 }

--- a/src/app/shared/services/migration/migration.service.ts
+++ b/src/app/shared/services/migration/migration.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { Plugins } from '@capacitor/core';
-import { BehaviorSubject, defer } from 'rxjs';
-import { concatMap, distinctUntilChanged, tap } from 'rxjs/operators';
+import { defer } from 'rxjs';
+import { concatMap } from 'rxjs/operators';
 import { VOID$ } from '../../../utils/rx-operators/rx-operators';
 import { MigratingDialogComponent } from '../../core/migrating-dialog/migrating-dialog.component';
 import {
@@ -20,10 +20,6 @@ const { Device } = Plugins;
   providedIn: 'root',
 })
 export class MigrationService {
-  private readonly _hasMigrated$ = new BehaviorSubject(false);
-  readonly hasMigrated$ = this._hasMigrated$
-    .asObservable()
-    .pipe(distinctUntilChanged());
   private readonly preferences = this.preferenceManager.getPreferences(
     MigrationService.name
   );
@@ -43,10 +39,7 @@ export class MigrationService {
     );
     return defer(() =>
       this.preferences.getBoolean(PrefKeys.TO_0_15_0, false)
-    ).pipe(
-      concatMap(hasMigrated => (hasMigrated ? VOID$ : runMigrate$)),
-      tap(() => this._hasMigrated$.next(true))
-    );
+    ).pipe(concatMap(hasMigrated => (hasMigrated ? VOID$ : runMigrate$)));
   }
 
   private async preMigrate() {

--- a/src/app/shared/services/migration/migration.service.ts
+++ b/src/app/shared/services/migration/migration.service.ts
@@ -70,12 +70,12 @@ export class MigrationService {
       data: { progress: 0 },
     });
 
-    await this.to0_15_0().catch(err => {
+    try {
+      await this.to0_15_0();
+      await this.onboardingService.setHasPrefetchedDiaBackendAssets(true);
+    } finally {
       dialogRef.close();
-      throw err;
-    });
-    await this.onboardingService.setHasPrefetchedDiaBackendAssets(true);
-    dialogRef.close();
+    }
   }
 
   async updatePreviousVersion() {


### PR DESCRIPTION
Fix the following conditions:
- If an error happens during migrating, the migration dialog will not be closed.
- If an error happens during migrating, the`HAS_PREFETCHED_DIA_BACKEND_ASSETS` preference will not be set to true while it should.
- If network is not connected (assuming that user is using the App offline), the migrating dialog will prompt and disappear everytime the user navigates to the home page.
- If an error happens during pre-fetching, the pre-fetching dialog will not be closed.