### PR TITLE
Fix iOS toolbar on Activity and CaptureDetails page

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -64,7 +64,7 @@
 		<string>armv7</string>
 	</array>
 	<key>UIStatusBarHidden</key>
-	<true/>
+	<false/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/src/global.scss
+++ b/src/global.scss
@@ -47,6 +47,7 @@ mat-toolbar {
 @media (min-width: 380px) {
   .ios mat-toolbar {
     padding-top: 30px;
+    min-height: 90px;
     height: 90px;
   }
 }
@@ -62,6 +63,7 @@ mat-toolbar {
 @media (min-height: 750px) {
   .ios mat-toolbar {
     padding-top: 30px;
+    min-height: 90px;
     height: 90px;
   }
 }


### PR DESCRIPTION
- Fix the toolbar height on iOS

- Revert the change to hide status bar on iOS

Signed-off-by: James Chien <shc261392@gmail.com>