### PR TITLE
Display stroked status style if the asset is not owned by the user.

### DIFF
--- a/src/app/features/home/transaction/transaction-details/transaction-details.page.scss
+++ b/src/app/features/home/transaction/transaction-details/transaction-details.page.scss
@@ -73,8 +73,13 @@ mat-toolbar {
 
   button.returned {
     color: white;
-    border-color: var(--ion-color-danger);
+    border-color: #e31587;
     background-color: #e31587;
+  }
+
+  button.missed {
+    color: #e31587;
+    border-color: #e31587;
   }
 }
 

--- a/src/app/features/home/transaction/transaction-details/transaction-details.page.ts
+++ b/src/app/features/home/transaction/transaction-details/transaction-details.page.ts
@@ -41,7 +41,10 @@ export async function getStatus(
 ) {
   const resolvedEmail = await email;
   if (transaction.expired) {
-    return Status.Returned;
+    if (transaction.sender === resolvedEmail) {
+      return Status.Returned;
+    }
+    return Status.Missed;
   }
   if (!transaction.fulfilled_at) {
     if (transaction.receiver_email === resolvedEmail) {
@@ -59,6 +62,7 @@ enum Status {
   waitingToBeAccepted = 'waitingToBeAccepted',
   InProgress = 'inProgress',
   Returned = 'returned',
+  Missed = 'missed',
   Delivered = 'delivered',
   Accepted = 'accepted',
 }

--- a/src/app/features/home/transaction/transaction.page.scss
+++ b/src/app/features/home/transaction/transaction.page.scss
@@ -61,8 +61,13 @@ mat-toolbar {
 
     button.returned {
       color: white;
-      border-color: var(--ion-color-danger);
+      border-color: #e31587;
       background-color: #e31587;
+    }
+
+    button.missed {
+      color: #e31587;
+      border-color: #e31587;
     }
   }
 }

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -142,6 +142,7 @@
     "accepted": "Accepted",
     "delivered": "Delivered",
     "returned": "Returned",
+    "missed": "Returned",
     "inProgress": "In Progress",
     "waitingToBeAccepted": "In Progress",
     "null": "Not Provided"

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -141,6 +141,7 @@
     "accepted": "已接收",
     "delivered": "已送出",
     "returned": "已退回",
+    "missed": "已退回",
     "inProgress": "等待中",
     "waitingToBeAccepted": "等待中",
     "null": "未提供"


### PR DESCRIPTION
According to the slack discussion:

> __@tammyyang__ 
> - asset 是我的 => 實心
> - asset 是別人的 => 空心
>
> 如果確定就是這個行為的話，就定下來
> QA 以後就用這個標準測
>
> __@wcchung__
> 這個標準我覺得也 OK，那目前就是接受者退回的 icon 需要改成空心