### PR TITLE
Add 'error' zh-tw translate.

### DIFF
--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -94,6 +94,7 @@
   "restore": "恢復",
   "skip": "跳過",
   "contactUs": "聯絡我們",
+  ".error": "錯誤",
   ".message": "訊息",
   "message": {
     "areYouSure": "此操作不可撤銷。",


### PR DESCRIPTION
The zh-TW translate of `error` is missing in the previous release.