### PR TITLE
Remove all user data on logging out.

### DIFF
--- a/src/app/shared/services/database/database.service.spec.ts
+++ b/src/app/shared/services/database/database.service.spec.ts
@@ -23,4 +23,14 @@ describe('Database', () => {
     const id = 'id';
     expect(database.getTable(id)).toBe(database.getTable(id));
   });
+
+  it('should clear all tables', async () => {
+    const id = 'id';
+    const table = database.getTable(id);
+    await table.insert([{ a: 1 }]);
+
+    await database.clear();
+
+    expect(await table.queryAll()).toEqual([]);
+  });
 });

--- a/src/app/shared/services/database/database.service.ts
+++ b/src/app/shared/services/database/database.service.ts
@@ -28,4 +28,8 @@ export class Database {
     this.tables.set(id, created);
     return created;
   }
+
+  async clear() {
+    return Promise.all([...this.tables.values()].map(table => table.clear()));
+  }
 }

--- a/src/app/shared/services/database/table/table.ts
+++ b/src/app/shared/services/database/table/table.ts
@@ -11,6 +11,7 @@ export interface Table<T extends Tuple> {
   ): Promise<T[]>;
   delete(tuples: T[], comparator?: (x: T, y: T) => boolean): Promise<T[]>;
   update(tuples: T[], comparator: (x: T, y: T) => boolean): Promise<T[]>;
+  clear(): Promise<void>;
   drop(): Promise<void>;
 }
 

--- a/src/app/shared/services/image-store/image-store.service.spec.ts
+++ b/src/app/shared/services/image-store/image-store.service.spec.ts
@@ -10,11 +10,6 @@ const { Filesystem } = Plugins;
 
 describe('ImageStore', () => {
   let store: ImageStore;
-  const sampleFile =
-    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
-  const sampleIndex =
-    '93ae7d494fad0fb30cbf3ae746a39c4bc7a0f8bbf87fbb587a3f3c01f3c5ce20';
-  const sampleMimeType: MimeType = 'image/png';
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -29,21 +24,21 @@ describe('ImageStore', () => {
   it('should be created', () => expect(store).toBeTruthy());
 
   it('should check if file exists', async () => {
-    expect(await store.exists(sampleIndex)).toBeFalse();
+    expect(await store.exists(INDEX)).toBeFalse();
   });
 
   it('should write file with Base64', async () => {
-    const index = await store.write(sampleFile, sampleMimeType);
+    const index = await store.write(FILE, MIME_TYPE);
     expect(await store.exists(index)).toBeTrue();
   });
 
   it('should read file with index', async () => {
-    const index = await store.write(sampleFile, sampleMimeType);
-    expect(await store.read(index)).toEqual(sampleFile);
+    const index = await store.write(FILE, MIME_TYPE);
+    expect(await store.read(index)).toEqual(FILE);
   });
 
   it('should delete file with index', async () => {
-    const index = await store.write(sampleFile, sampleMimeType);
+    const index = await store.write(FILE, MIME_TYPE);
 
     await store.delete(index);
 
@@ -51,8 +46,8 @@ describe('ImageStore', () => {
   });
 
   it('should delete file with index and thumbnail', async () => {
-    const index = await store.write(sampleFile, sampleMimeType);
-    await store.readThumbnail(index, sampleMimeType);
+    const index = await store.write(FILE, MIME_TYPE);
+    await store.readThumbnail(index, MIME_TYPE);
 
     await store.delete(index);
 
@@ -60,10 +55,10 @@ describe('ImageStore', () => {
   });
 
   it('should remove all files after drop', async () => {
-    const index1 = await store.write(sampleFile, sampleMimeType);
+    const index1 = await store.write(FILE, MIME_TYPE);
     const anotherFile =
       'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAAAXRSTlPM0jRW/QAAAApJREFUeJxjYgAAAAYAAzY3fKgAAAAASUVORK5CYII=';
-    const index2 = await store.write(anotherFile, sampleMimeType);
+    const index2 = await store.write(anotherFile, MIME_TYPE);
 
     await store.drop();
 
@@ -78,7 +73,7 @@ describe('ImageStore', () => {
     );
 
     const indexes = await Promise.all(
-      files.map(file => store.write(file, sampleMimeType))
+      files.map(file => store.write(file, MIME_TYPE))
     );
 
     for (const index of indexes) {
@@ -94,7 +89,7 @@ describe('ImageStore', () => {
     const indexes = [];
 
     for (const file of files) {
-      indexes.push(await store.write(file, sampleMimeType));
+      indexes.push(await store.write(file, MIME_TYPE));
     }
 
     await Promise.all(indexes.map(index => store.delete(index)));
@@ -105,8 +100,22 @@ describe('ImageStore', () => {
   });
 
   it('should read thumbnail', async () => {
-    const index = await store.write(sampleFile, sampleMimeType);
-    const thumbnailFile = await store.readThumbnail(index, sampleMimeType);
+    const index = await store.write(FILE, MIME_TYPE);
+    const thumbnailFile = await store.readThumbnail(index, MIME_TYPE);
     expect(thumbnailFile).toBeTruthy();
   });
+
+  it('should clear all files', async () => {
+    const index = await store.write(FILE, MIME_TYPE);
+
+    await store.clear();
+
+    expect(await store.exists(index)).toBeFalse();
+  });
 });
+
+const FILE =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+const INDEX =
+  '93ae7d494fad0fb30cbf3ae746a39c4bc7a0f8bbf87fbb587a3f3c01f3c5ce20';
+const MIME_TYPE: MimeType = 'image/png';

--- a/src/app/shared/services/image-store/image-store.service.ts
+++ b/src/app/shared/services/image-store/image-store.service.ts
@@ -219,9 +219,10 @@ export class ImageStore {
     return index;
   }
 
-  async drop() {
+  async clear() {
     await this.initialize();
-    await this.thumbnailTable.drop();
+    await this.extensionTable.clear();
+    await this.thumbnailTable.clear();
     return this.mutex.runExclusive(async () => {
       this.hasInitialized = false;
       await this.filesystemPlugin.rmdir({
@@ -230,6 +231,12 @@ export class ImageStore {
         recursive: true,
       });
     });
+  }
+
+  async drop() {
+    await this.clear();
+    await this.extensionTable.drop();
+    await this.thumbnailTable.drop();
   }
 }
 

--- a/src/app/shared/services/preference-manager/preference-manager.service.spec.ts
+++ b/src/app/shared/services/preference-manager/preference-manager.service.spec.ts
@@ -23,4 +23,22 @@ describe('PreferenceManager', () => {
     const id = 'id';
     expect(manager.getPreferences(id)).toBe(manager.getPreferences(id));
   });
+
+  it('should clear all preferences', async () => {
+    const key = 'key';
+    const defaultValue = 99;
+    const preference1 = manager.getPreferences('id1');
+    const preference2 = manager.getPreferences('id2');
+    await preference1.setNumber(key, 1);
+    await preference2.setNumber(key, 2);
+
+    await manager.clear();
+
+    expect(await preference1.getNumber(key, defaultValue)).toEqual(
+      defaultValue
+    );
+    expect(await preference2.getNumber(key, defaultValue)).toEqual(
+      defaultValue
+    );
+  });
 });

--- a/src/app/shared/services/preference-manager/preference-manager.service.ts
+++ b/src/app/shared/services/preference-manager/preference-manager.service.ts
@@ -27,4 +27,10 @@ export class PreferenceManager {
     this.preferencesMap.set(id, created);
     return created;
   }
+
+  async clear() {
+    return Promise.all(
+      [...this.preferencesMap.values()].map(preferences => preferences.clear())
+    );
+  }
 }

--- a/src/app/shared/services/preference-manager/preferences/capacitor-storage-preferences/capacitor-storage-preferences.spec.ts
+++ b/src/app/shared/services/preference-manager/preferences/capacitor-storage-preferences/capacitor-storage-preferences.spec.ts
@@ -213,4 +213,15 @@ describe('CapacitorStoragePreferences', () => {
         done();
       });
   });
+
+  it('should clear idempotently', async () => {
+    const key = 'key';
+    const expected = 2;
+    await preferences.setNumber(key, 1);
+
+    await preferences.clear();
+    await preferences.clear();
+
+    expect(await preferences.getNumber(key, expected)).toEqual(expected);
+  });
 });

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -32,7 +32,6 @@
   "signUp": "Sign Up",
   "required": "Required",
   "tooShort": "Too Short",
-  "talkingToTheServer": "Talking to the Server",
   "unknownError": "Unknown Error",
   "low": "Low",
   "high": "High",

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -32,7 +32,6 @@
   "signUp": "註冊",
   "required": "必填",
   "tooShort": "太短",
-  "talkingToTheServer": "與伺服器連線中",
   "unknownError": "未知的錯誤",
   "low": "低",
   "high": "高",


### PR DESCRIPTION
See #369. This PR has several changes regarding data persistence.

- Add `clear` method on `Database`.
- Add `clear` method on `Table` interface.
- Add `clear` method on `PreferenceManager`.
- Adjust `clear` method on `Preferences` interface.
    - Each preference will be `undefined` after being `clear`ed.
    - Each preference `Observable` will __NOT__ emit new value after being `clear`ed (with `isNonNullable` operator).
    - Each preference `Promise` will emit the default value after being `clear`ed.
- Adjust function types on `Preferences` implementations.
- Add `clear` method on `ImageStore`.
- After `DiaBackendAuthService.logout$()`
    - Clear all user data: `ImageStore`, `Database` and `PreferenceManager`.
    - Reload the app to re-initialize app.

This PR has been tested on Brave browser and Exodus 1.