### PR TITLE
Open Google maps with external URL on clicking location info.

### DIFF
--- a/src/app/features/home/capture-tab/capture-details/capture-details.page.html
+++ b/src/app/features/home/capture-tab/capture-details/capture-details.page.html
@@ -24,7 +24,7 @@
     </mat-list-item>
     <mat-list-item>
       <mat-icon mat-list-icon>place</mat-icon>
-      <div mat-line>
+      <div mat-line (click)="openMap()">
         {{ location$ | async }}
       </div>
     </mat-list-item>

--- a/src/app/features/home/capture-tab/capture-details/capture-details.page.ts
+++ b/src/app/features/home/capture-tab/capture-details/capture-details.page.ts
@@ -166,6 +166,26 @@ export class CaptureDetailsPage {
       .subscribe();
   }
 
+  openMap() {
+    return this.proof$
+      .pipe(
+        concatMap(proof =>
+          iif(
+            () =>
+              proof.geolocationLatitude !== undefined &&
+              proof.geolocationLongitude !== undefined,
+            defer(() =>
+              Browser.open({
+                url: `https://maps.google.com/maps?q=${proof.geolocationLatitude}, ${proof.geolocationLongitude}`,
+              })
+            )
+          )
+        ),
+        untilDestroyed(this)
+      )
+      .subscribe();
+  }
+
   private share() {
     this.proof$
       .pipe(

--- a/src/app/features/home/capture-tab/capture-details/capture-details.page.ts
+++ b/src/app/features/home/capture-tab/capture-details/capture-details.page.ts
@@ -21,6 +21,7 @@ import { DiaBackendAssetRepository } from '../../../../shared/services/dia-backe
 import { DiaBackendAuthService } from '../../../../shared/services/dia-backend/auth/dia-backend-auth.service';
 import { ImageStore } from '../../../../shared/services/image-store/image-store.service';
 import { getOldProof } from '../../../../shared/services/repositories/proof/old-proof-adapter';
+import { Proof } from '../../../../shared/services/repositories/proof/proof';
 import { ProofRepository } from '../../../../shared/services/repositories/proof/proof-repository.service';
 import { ShareService } from '../../../../shared/services/share/share.service';
 import { blobToBase64 } from '../../../../utils/encoding/encoding';
@@ -74,12 +75,10 @@ export class CaptureDetailsPage {
   );
   readonly location$ = this.proof$.pipe(
     map(proof => {
-      const latitude = proof.geolocationLatitude;
-      const longitude = proof.geolocationLongitude;
-      if (!latitude || !longitude) {
-        return this.translacoService.translate('locationNotProvided');
+      if (isValidGeolocation(proof)) {
+        return `${proof.geolocationLatitude}, ${proof.geolocationLongitude}`;
       }
-      return `${latitude}, ${longitude}`;
+      return this.translacoService.translate('locationNotProvided');
     })
   );
   readonly email$ = this.diaBackendAuthService.getEmail$;
@@ -171,12 +170,10 @@ export class CaptureDetailsPage {
       .pipe(
         concatMap(proof =>
           iif(
-            () =>
-              proof.geolocationLatitude !== undefined &&
-              proof.geolocationLongitude !== undefined,
+            () => isValidGeolocation(proof),
             defer(() =>
               Browser.open({
-                url: `https://maps.google.com/maps?q=${proof.geolocationLatitude}, ${proof.geolocationLongitude}`,
+                url: `https://maps.google.com/maps?q=${proof.geolocationLatitude},${proof.geolocationLongitude}`,
               })
             )
           )
@@ -225,4 +222,13 @@ export class CaptureDetailsPage {
         .subscribe();
     }
   }
+}
+
+function isValidGeolocation(proof: Proof) {
+  return proof.geolocationLatitude === undefined ||
+    proof.geolocationLatitude === 'undefined' ||
+    proof.geolocationLongitude === undefined ||
+    proof.geolocationLongitude === 'undefined'
+    ? false
+    : true;
 }


### PR DESCRIPTION
The maps will be opened with Capacitor `Browser` plugin. Thus, the map would be the website of Google map instead of Google map app.

This PR has been tested on Brave browser and Exodus 1.