### PR TITLE
Improve register performance

### DIFF
--- a/src/app/features/home/capture-tab/capture-details/options-menu/options-menu.component.html
+++ b/src/app/features/home/capture-tab/capture-details/options-menu/options-menu.component.html
@@ -1,6 +1,6 @@
 <mat-nav-list *transloco="let t">
   <a
-    *ngIf="data.proof.diaBackendAssetId"
+    *ngIf="data.proof.diaBackendAssetId && (asset$ | async)?.sharable_copy"
     mat-list-item
     (click)="openLink(options.Share)"
   >

--- a/src/app/features/home/capture-tab/capture-details/options-menu/options-menu.component.ts
+++ b/src/app/features/home/capture-tab/capture-details/options-menu/options-menu.component.ts
@@ -3,7 +3,10 @@ import {
   MatBottomSheetRef,
   MAT_BOTTOM_SHEET_DATA,
 } from '@angular/material/bottom-sheet';
+import { distinctUntilChanged } from 'rxjs/operators';
+import { DiaBackendAssetRepository } from '../../../../../shared/services/dia-backend/asset/dia-backend-asset-repository.service';
 import { Proof } from '../../../../../shared/services/repositories/proof/proof';
+import { isNonNullable } from '../../../../../utils/rx-operators/rx-operators';
 @Component({
   selector: 'app-options-menu',
   templateUrl: './options-menu.component.html',
@@ -11,9 +14,14 @@ import { Proof } from '../../../../../shared/services/repositories/proof/proof';
 })
 export class OptionsMenuComponent {
   readonly options = Option;
+  readonly asset$ = this.diaBackendAssetRepository
+    .fetchByProof$(this.data.proof)
+    .pipe(isNonNullable(), distinctUntilChanged());
+
   constructor(
     private readonly bottomSheetRef: MatBottomSheetRef<OptionsMenuComponent>,
-    @Inject(MAT_BOTTOM_SHEET_DATA) readonly data: { proof: Proof }
+    @Inject(MAT_BOTTOM_SHEET_DATA) readonly data: { proof: Proof },
+    private readonly diaBackendAssetRepository: DiaBackendAssetRepository
   ) {}
 
   openLink(option: Option) {

--- a/src/app/features/home/capture-tab/capture-details/sending-post-capture/sending-post-capture.page.html
+++ b/src/app/features/home/capture-tab/capture-details/sending-post-capture/sending-post-capture.page.html
@@ -9,7 +9,7 @@
   <ng-container *ngIf="!isPreview">
     <form #form="ngForm" (ngSubmit)="preview()">
       <mat-card class="example-card">
-        <img mat-card-image [src]="(asset$ | async)?.sharable_copy" />
+        <img mat-card-image [attr.src]="assetFileUrl$ | async" />
         <mat-card-content>
           <mat-form-field appearance="outline">
             <mat-label>{{ t('.message') }}</mat-label>

--- a/src/app/shared/core/post-capture-card/post-capture-card.component.html
+++ b/src/app/shared/core/post-capture-card/post-capture-card.component.html
@@ -13,14 +13,12 @@
         <mat-icon>more_vert</mat-icon>
       </button>
     </mat-card-header>
-    <div class="fixed-ratio">
-      <img
-        #ratioImg
-        id="image"
-        [src]="postCapture.sharable_copy"
-        mat-card-image
-      />
-    </div>
+    <img
+      #ratioImg
+      class="fixed-ratio-image"
+      [src]="postCapture.sharable_copy"
+      mat-card-image
+    />
     <mat-card-content>
       <p class="caption mat-body">
         {{ postCapture.caption }}

--- a/src/app/shared/core/post-capture-card/post-capture-card.component.scss
+++ b/src/app/shared/core/post-capture-card/post-capture-card.component.scss
@@ -17,20 +17,12 @@ mat-card {
   width: 100vw;
 }
 
-mat-card .fixed-ratio {
-  padding: 0;
-  margin: 0;
-  background-color: white;
-  max-width: 100vw;
-  width: 100vw;
-  height: 100vw;
-  overflow: hidden;
-}
-
-mat-card img {
-  padding: 0;
-  margin: 0;
+.fixed-ratio-image {
   width: 100%;
+  height: 100vw;
+  margin: 0;
+  object-fit: cover;
+  object-position: center;
 }
 
 mat-card-header {

--- a/src/app/shared/services/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/shared/services/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -74,7 +74,9 @@ export class DiaBackendAssetRepository {
           params: { proof_hash: getOldProof(proof).hash },
         })
       ),
-      map(listAssetResponse => listAssetResponse.results[0])
+      map(listAssetResponse =>
+        listAssetResponse.count >= 0 ? listAssetResponse.results[0] : undefined
+      )
     );
   }
 

--- a/src/app/shared/services/dia-backend/asset/uploading/dia-backend-asset-uploading.service.ts
+++ b/src/app/shared/services/dia-backend/asset/uploading/dia-backend-asset-uploading.service.ts
@@ -124,6 +124,7 @@ export class DiaBackendAssetUploadingService {
         }
         return throwError(err);
       }),
+      isNonNullable(),
       map(diaBackendAsset => {
         proof.diaBackendAssetId = diaBackendAsset.id;
         return proof;


### PR DESCRIPTION
Improve the register performance by

- Using offline preview image on sending-post-capture page.
- Checking if `sharable_copy` is available from the backend before showing share moment option on capture-details page.

The PR has been tested on Brave browser and Exodus 1.