### PR TITLE
Update PostCapture grid layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "lodash": "^4.17.20",
         "material-design-icons-iconfont": "^6.1.0",
         "merge-images": "^2.0.0",
-        "ngx-virtual-scroller": "^4.0.3",
         "rxjs": "~6.6.3",
         "tslib": "^2.0.1",
         "zone.js": "~0.10.2"
@@ -2909,11 +2908,6 @@
         "typescript": "~3.9.7"
       }
     },
-    "node_modules/@tweenjs/tween.js": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-17.4.0.tgz",
-      "integrity": "sha512-J3fzl1F6wvh8KXVVcIuHN12xi1ZDcPA/0Vix+ZcJYwZWVHUwfIqfvzYXXEw7ybeev6477KCTt9fKydU+ajUqcg=="
-    },
     "node_modules/@types/cordova": {
       "version": "0.0.34",
       "resolved": "https://registry.npmjs.org/@types/cordova/-/cordova-0.0.34.tgz",
@@ -3015,11 +3009,6 @@
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
       "dev": true
-    },
-    "node_modules/@types/tween.js": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@types/tween.js/-/tween.js-17.2.0.tgz",
-      "integrity": "sha512-mOsqurEtFEzwgkVc/jDVE2XrjZBYTbrmDUyCr9GXmnfc6q5otokxFtKvSY/B21zgz9LVRIvRTawKczjKi57wrA=="
     },
     "node_modules/@types/unist": {
       "version": "2.0.3",
@@ -11360,15 +11349,6 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
-    },
-    "node_modules/ngx-virtual-scroller": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ngx-virtual-scroller/-/ngx-virtual-scroller-4.0.3.tgz",
-      "integrity": "sha512-JBqUJ/f7GRCZDnI/JeiFoTmYR8rC/Hyv8L5I7ImePM6f/hwiFNRsrK8Abdd0E3TwklwgmZAK875te9XQJrgsyQ==",
-      "dependencies": {
-        "@tweenjs/tween.js": "17.4.0",
-        "@types/tween.js": "17.2.0"
-      }
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -22004,11 +21984,6 @@
         "typescript": "~3.9.7"
       }
     },
-    "@tweenjs/tween.js": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-17.4.0.tgz",
-      "integrity": "sha512-J3fzl1F6wvh8KXVVcIuHN12xi1ZDcPA/0Vix+ZcJYwZWVHUwfIqfvzYXXEw7ybeev6477KCTt9fKydU+ajUqcg=="
-    },
     "@types/cordova": {
       "version": "0.0.34",
       "resolved": "https://registry.npmjs.org/@types/cordova/-/cordova-0.0.34.tgz",
@@ -22110,11 +22085,6 @@
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
       "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
       "dev": true
-    },
-    "@types/tween.js": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@types/tween.js/-/tween.js-17.2.0.tgz",
-      "integrity": "sha512-mOsqurEtFEzwgkVc/jDVE2XrjZBYTbrmDUyCr9GXmnfc6q5otokxFtKvSY/B21zgz9LVRIvRTawKczjKi57wrA=="
     },
     "@types/unist": {
       "version": "2.0.3",
@@ -29161,15 +29131,6 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
-    },
-    "ngx-virtual-scroller": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ngx-virtual-scroller/-/ngx-virtual-scroller-4.0.3.tgz",
-      "integrity": "sha512-JBqUJ/f7GRCZDnI/JeiFoTmYR8rC/Hyv8L5I7ImePM6f/hwiFNRsrK8Abdd0E3TwklwgmZAK875te9XQJrgsyQ==",
-      "requires": {
-        "@tweenjs/tween.js": "17.4.0",
-        "@types/tween.js": "17.2.0"
-      }
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "lodash": "^4.17.20",
     "material-design-icons-iconfont": "^6.1.0",
     "merge-images": "^2.0.0",
-    "ngx-virtual-scroller": "^4.0.3",
     "rxjs": "~6.6.3",
     "tslib": "^2.0.1",
     "zone.js": "~0.10.2"

--- a/src/app/features/home/capture-tab/capture-details/capture-details.page.ts
+++ b/src/app/features/home/capture-tab/capture-details/capture-details.page.ts
@@ -78,7 +78,7 @@ export class CaptureDetailsPage {
       if (isValidGeolocation(proof)) {
         return `${proof.geolocationLatitude}, ${proof.geolocationLongitude}`;
       }
-      return this.translacoService.translate('locationNotProvided');
+      return this.translocoService.translate('locationNotProvided');
     })
   );
   readonly email$ = this.diaBackendAuthService.getEmail$;
@@ -90,7 +90,7 @@ export class CaptureDetailsPage {
     private readonly blockingActionService: BlockingActionService,
     private readonly dialog: MatDialog,
     private readonly bottomSheet: MatBottomSheet,
-    private readonly translacoService: TranslocoService,
+    private readonly translocoService: TranslocoService,
     private readonly proofRepository: ProofRepository,
     private readonly diaBackendAuthService: DiaBackendAuthService,
     private readonly diaBackendAssetRepository: DiaBackendAssetRepository,

--- a/src/app/features/home/capture-tab/capture-tab.component.html
+++ b/src/app/features/home/capture-tab/capture-tab.component.html
@@ -27,8 +27,8 @@
         alt="Photo of a Shiba Inu"
       />
     </div>
-    <mat-card-title
-      >{{ username$ | async }}
+    <mat-card-title>
+      {{ username$ | async }}
       <button mat-button (click)="editUsername()">
         <mat-icon class="edit-icon">edit</mat-icon>
       </button>

--- a/src/app/features/home/capture-tab/capture-tab.component.html
+++ b/src/app/features/home/capture-tab/capture-tab.component.html
@@ -44,7 +44,7 @@
       trackBy: trackCaptureGroupByDate
     "
   >
-    <div class="mat-title">{{ group.key }}</div>
+    <div class="mat-title">{{ group.key | date: 'longDate' }}</div>
     <mat-grid-list cols="3" gutterSize="8px">
       <mat-grid-tile
         *ngFor="let captureItem of group.value; trackBy: trackCaptureItem"

--- a/src/app/features/home/capture-tab/capture-tab.component.scss
+++ b/src/app/features/home/capture-tab/capture-tab.component.scss
@@ -10,7 +10,7 @@
 
 div.mat-title {
   margin: 26px 0 0;
-  font-size: large;
+  font-size: medium;
 }
 
 .user-card {

--- a/src/app/features/home/capture-tab/capture-tab.component.spec.ts
+++ b/src/app/features/home/capture-tab/capture-tab.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SharedTestingModule } from '../../../shared/shared-testing.module';
 import { CaptureTabComponent } from './capture-tab.component';
+import { UploadingBarComponent } from './uploading-bar/uploading-bar.component';
 
 describe('CaptureTabComponent', () => {
   let component: CaptureTabComponent;
@@ -8,7 +9,7 @@ describe('CaptureTabComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [CaptureTabComponent],
+      declarations: [CaptureTabComponent, UploadingBarComponent],
       imports: [SharedTestingModule],
     }).compileComponents();
 

--- a/src/app/features/home/capture-tab/capture-tab.component.ts
+++ b/src/app/features/home/capture-tab/capture-tab.component.ts
@@ -131,9 +131,9 @@ export class CaptureTabComponent {
 }
 
 interface CaptureItem {
-  proof: Proof;
-  thumbnailUrl?: string;
-  oldProofHash: string;
-  isCollecting: boolean;
-  hasGeolocation: boolean;
+  readonly proof: Proof;
+  readonly thumbnailUrl?: string;
+  readonly oldProofHash: string;
+  readonly isCollecting: boolean;
+  readonly hasGeolocation: boolean;
 }

--- a/src/app/features/home/capture-tab/capture-tab.component.ts
+++ b/src/app/features/home/capture-tab/capture-tab.component.ts
@@ -109,7 +109,6 @@ export class CaptureTabComponent {
     a: KeyValue<number, string>,
     b: KeyValue<number, string>
   ): number {
-    console.log(a.key);
     return a.key > b.key ? -1 : b.key > a.key ? 1 : 0;
   }
 

--- a/src/app/features/home/capture-tab/capture-tab.component.ts
+++ b/src/app/features/home/capture-tab/capture-tab.component.ts
@@ -45,7 +45,7 @@ export class CaptureTabComponent {
     ),
     map(captures =>
       groupBy(captures, capture =>
-        formatDate(capture.proof.timestamp, 'longDate', 'en-US')
+        formatDate(capture.proof.timestamp, 'yyyy/MM/dd', 'en-US')
       )
     )
   );
@@ -109,6 +109,7 @@ export class CaptureTabComponent {
     a: KeyValue<number, string>,
     b: KeyValue<number, string>
   ): number {
+    console.log(a.key);
     return a.key > b.key ? -1 : b.key > a.key ? 1 : 0;
   }
 

--- a/src/app/features/home/home-routing.module.ts
+++ b/src/app/features/home/home-routing.module.ts
@@ -33,6 +33,13 @@ const routes: Routes = [
         m => m.TutorialPageModule
       ),
   },
+  {
+    path: 'post-capture-details',
+    loadChildren: () =>
+      import(
+        './post-capture-tab/post-capture-details/post-capture-details.module'
+      ).then(m => m.PostCaptureDetailsPageModule),
+  },
 ];
 
 @NgModule({

--- a/src/app/features/home/home.module.ts
+++ b/src/app/features/home/home.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import { PostCaptureCardModule } from '../../shared/core/post-capture-card/post-capture-card.module';
 import { SharedModule } from '../../shared/shared.module';
 import { CaptureTabComponent } from './capture-tab/capture-tab.component';
@@ -9,12 +8,7 @@ import { HomePage } from './home.page';
 import { PrefetchingDialogComponent } from './onboarding/prefetching-dialog/prefetching-dialog.component';
 import { PostCaptureTabComponent } from './post-capture-tab/post-capture-tab.component';
 @NgModule({
-  imports: [
-    SharedModule,
-    HomePageRoutingModule,
-    PostCaptureCardModule,
-    VirtualScrollerModule,
-  ],
+  imports: [SharedModule, HomePageRoutingModule, PostCaptureCardModule],
   declarations: [
     HomePage,
     CaptureTabComponent,

--- a/src/app/features/home/home.page.scss
+++ b/src/app/features/home/home.page.scss
@@ -26,8 +26,8 @@ mat-sidenav-content {
 }
 
 .postcapture-tab-icon {
-  height: 24px;
-  width: 24px;
+  height: 20px;
+  width: 20px;
   color: white;
 }
 

--- a/src/app/features/home/home.page.spec.ts
+++ b/src/app/features/home/home.page.spec.ts
@@ -1,6 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
-import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import { SharedTestingModule } from '../../shared/shared-testing.module';
 import { CaptureTabComponent } from './capture-tab/capture-tab.component';
 import { UploadingBarComponent } from './capture-tab/uploading-bar/uploading-bar.component';
@@ -19,7 +18,7 @@ describe('HomePage', () => {
         PostCaptureTabComponent,
         UploadingBarComponent,
       ],
-      imports: [SharedTestingModule, VirtualScrollerModule],
+      imports: [SharedTestingModule],
     }).compileComponents();
 
     const router = TestBed.inject(Router);

--- a/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details-routing.module.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { PostCaptureDetailsPage } from './post-capture-details.page';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: PostCaptureDetailsPage,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class PostCaptureDetailsPageRoutingModule {}

--- a/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.module.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { SharedModule } from '../../../../shared/shared.module';
+import { PostCaptureDetailsPageRoutingModule } from './post-capture-details-routing.module';
+import { PostCaptureDetailsPage } from './post-capture-details.page';
+
+@NgModule({
+  imports: [SharedModule, PostCaptureDetailsPageRoutingModule],
+  declarations: [PostCaptureDetailsPage],
+})
+export class PostCaptureDetailsPageModule {}

--- a/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.html
+++ b/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.html
@@ -1,0 +1,37 @@
+<mat-toolbar color="primary" *transloco="let t">
+  <button routerLink=".." routerDirection="back" mat-icon-button>
+    <mat-icon>arrow_back</mat-icon>
+  </button>
+  <div class="toolbar-spacer"></div>
+  <button (click)="openOptionsMenu()" mat-icon-button>
+    <mat-icon>more_vert</mat-icon>
+  </button>
+</mat-toolbar>
+
+<mat-list>
+  <img [attr.src]="(diaBackendAsset$ | async)?.asset_file" />
+  <mat-list-item>
+    <mat-icon mat-list-icon>person</mat-icon>
+    <div mat-line>{{ (diaBackendAsset$ | async)?.owner }}</div>
+  </mat-list-item>
+  <mat-list-item>
+    <mat-icon mat-list-icon>place</mat-icon>
+    <div mat-line (click)="openMap()">
+      {{ location$ | async }}
+    </div>
+  </mat-list-item>
+  <mat-list-item>
+    <mat-icon mat-list-icon>access_time</mat-icon>
+    <div mat-line>
+      {{
+        (diaBackendAsset$ | async)?.information.proof?.timestamp | date: 'long'
+      }}
+    </div>
+  </mat-list-item>
+  <mat-list-item>
+    <mat-icon svgIcon="media-id-solid-black" mat-list-icon></mat-icon>
+    <div mat-line>
+      {{ (diaBackendAsset$ | async)?.id }}
+    </div>
+  </mat-list-item>
+</mat-list>

--- a/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.scss
+++ b/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.scss
@@ -1,0 +1,17 @@
+:host {
+  justify-content: start;
+}
+
+.toolbar-spacer {
+  flex: 1 1 auto;
+}
+
+mat-list {
+  overflow: scroll;
+  padding-top: 0;
+}
+
+.mat-list-base .mat-list-item.mat-list-item-with-avatar {
+  height: 40px;
+  padding: 0 20px;
+}

--- a/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.spec.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.spec.ts
@@ -1,0 +1,23 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { SharedTestingModule } from '../../../../shared/shared-testing.module';
+import { PostCaptureDetailsPage } from './post-capture-details.page';
+
+describe('PostCaptureDetailsPage', () => {
+  let component: PostCaptureDetailsPage;
+  let fixture: ComponentFixture<PostCaptureDetailsPage>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [PostCaptureDetailsPage],
+      imports: [SharedTestingModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PostCaptureDetailsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.ts
@@ -1,0 +1,122 @@
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { Browser } from '@capacitor/core';
+import { ActionSheetController } from '@ionic/angular';
+import { TranslocoService } from '@ngneat/transloco';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { zip } from 'rxjs';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
+import {
+  DiaBackendAsset,
+  DiaBackendAssetRepository,
+} from '../../../../shared/services/dia-backend/asset/dia-backend-asset-repository.service';
+import { DiaBackendAuthService } from '../../../../shared/services/dia-backend/auth/dia-backend-auth.service';
+import { OldDefaultInformationName } from '../../../../shared/services/repositories/proof/old-proof-adapter';
+import { ShareService } from '../../../../shared/services/share/share.service';
+import { isNonNullable } from '../../../../utils/rx-operators/rx-operators';
+
+@UntilDestroy()
+@Component({
+  selector: 'app-post-capture-details',
+  templateUrl: './post-capture-details.page.html',
+  styleUrls: ['./post-capture-details.page.scss'],
+})
+export class PostCaptureDetailsPage {
+  readonly diaBackendAsset$ = this.route.paramMap.pipe(
+    map(params => params.get('id')),
+    isNonNullable(),
+    switchMap(id => this.diaBackendAssetRepository.fetchById$(id)),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  readonly location$ = this.diaBackendAsset$.pipe(
+    map(diaBackendAsset => {
+      const geolocation = getValidGeolocation(diaBackendAsset);
+      if (geolocation) {
+        return `${geolocation.latitude}, ${geolocation.longitude}`;
+      }
+      return this.translocoService.translate<string>('locationNotProvided');
+    })
+  );
+
+  constructor(
+    private readonly route: ActivatedRoute,
+    private readonly diaBackendAssetRepository: DiaBackendAssetRepository,
+    private readonly translocoService: TranslocoService,
+    private readonly actionSheetController: ActionSheetController,
+    private readonly shareService: ShareService,
+    private readonly diaBackendAuthService: DiaBackendAuthService
+  ) {}
+
+  async openOptionsMenu() {
+    const actionSheet = await this.actionSheetController.create({
+      buttons: [
+        {
+          text: this.translocoService.translate('message.shareMoment'),
+          handler: () => {
+            this.share();
+          },
+        },
+        {
+          text: this.translocoService.translate(
+            'message.viewBlockchainCertificate'
+          ),
+          handler: () => {
+            this.openCertificate();
+          },
+        },
+      ],
+    });
+    return actionSheet.present();
+  }
+
+  private share() {
+    return this.diaBackendAsset$
+      .pipe(
+        switchMap(diaBackendAsset => this.shareService.share(diaBackendAsset)),
+        untilDestroyed(this)
+      )
+      .subscribe();
+  }
+
+  private openCertificate() {
+    return zip(this.diaBackendAsset$, this.diaBackendAuthService.token$)
+      .pipe(
+        switchMap(([diaBackendAsset, token]) =>
+          Browser.open({
+            url: `https://authmedia.net/dia-certificate?mid=${diaBackendAsset.id}&token=${token}`,
+          })
+        ),
+        untilDestroyed(this)
+      )
+      .subscribe();
+  }
+
+  openMap() {
+    return this.diaBackendAsset$
+      .pipe(
+        map(getValidGeolocation),
+        isNonNullable(),
+        switchMap(geolocation =>
+          Browser.open({
+            url: `https://maps.google.com/maps?q=${geolocation.latitude},${geolocation.longitude}`,
+          })
+        ),
+        untilDestroyed(this)
+      )
+      .subscribe();
+  }
+}
+
+function getValidGeolocation(diaBackendAsset: DiaBackendAsset) {
+  const latitude = diaBackendAsset.information.information?.find(
+    info => info.name === OldDefaultInformationName.GEOLOCATION_LATITUDE
+  )?.value;
+  const longitude = diaBackendAsset.information.information?.find(
+    info => info.name === OldDefaultInformationName.GEOLOCATION_LONGITUDE
+  )?.value;
+  if (latitude && longitude) {
+    return { latitude, longitude };
+  }
+  return undefined;
+}

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.html
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.html
@@ -1,6 +1,7 @@
 <mat-grid-list *ngIf="networkConnected$ | async" cols="3" gutterSize="8px">
   <mat-grid-tile
     *ngFor="let postCapture of postCaptures$ | async; trackBy: trackPostCapture"
+    [routerLink]="['post-capture-details', { id: postCapture.id }]"
   >
     <ion-icon
       *ngIf="postCapture.hasGeolocation"

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.html
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.html
@@ -1,16 +1,12 @@
-<div *ngIf="networkConnected$ | async" class="tab-content-post" #scrollingBlock>
-  <virtual-scroller
-    #scroll
-    [items]="postCaptures$ | async"
-    [parentScroll]="scrollingBlock"
-    [enableUnequalChildrenSizes]="true"
-    [bufferAmount]="2"
-    (vsEnd)="loadNextPage($event)"
+<mat-grid-list *ngIf="networkConnected$ | async" cols="3" gutterSize="8px">
+  <mat-grid-tile
+    *ngFor="let postCapture of postCaptures$ | async; trackBy: trackPostCapture"
   >
-    <app-post-capture-card
-      *ngFor="let item of scroll.viewPortItems; trackBy: trackPostCapture"
-      [postCapture]="item"
-    >
-    </app-post-capture-card>
-  </virtual-scroller>
-</div>
+    <ion-icon
+      *ngIf="postCapture.hasGeolocation"
+      src="/assets/icon/location.svg"
+      class="located"
+    ></ion-icon>
+    <ion-img [src]="postCapture.thumbnailUrl"></ion-img>
+  </mat-grid-tile>
+</mat-grid-list>

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.scss
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.scss
@@ -1,10 +1,28 @@
-.tab-content-post {
-  virtual-scroller {
-    width: 100vw;
-    height: 100vh;
+:host {
+  display: block;
+  padding: 8px;
+}
+
+mat-grid-tile {
+  ion-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    overflow: hidden;
+    border-radius: 4px;
   }
 
-  app-post-capture-card {
-    width: 100%;
+  ion-icon {
+    color: white;
+    z-index: 10;
+  }
+
+  ion-icon.located {
+    position: absolute;
+    bottom: 9px;
+    left: 5px;
+    font-size: 13px;
+    opacity: 30%;
   }
 }

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.spec.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.spec.ts
@@ -1,5 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { VirtualScrollerModule } from 'ngx-virtual-scroller';
 import { SharedTestingModule } from '../../../shared/shared-testing.module';
 import { PostCaptureTabComponent } from './post-capture-tab.component';
 
@@ -10,7 +9,7 @@ describe('PostCaptureTabComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [PostCaptureTabComponent],
-      imports: [SharedTestingModule, VirtualScrollerModule],
+      imports: [SharedTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(PostCaptureTabComponent);

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
@@ -79,7 +79,7 @@ export class PostCaptureTabComponent implements OnInit {
       map(assets => assets.filter(asset => asset.source_transaction)),
       map(assets =>
         assets.map<PostCaptureItem>(asset => ({
-          oldProofHash: asset.proof_hash,
+          id: asset.id,
           thumbnailUrl: asset.asset_file_thumbnail,
           hasGeolocation: !!asset.information.information?.find(
             info => info.name === OldDefaultInformationName.GEOLOCATION_LATITUDE
@@ -97,7 +97,7 @@ export class PostCaptureTabComponent implements OnInit {
 }
 
 interface PostCaptureItem {
-  readonly oldProofHash: string;
+  readonly id: string;
   readonly thumbnailUrl: string;
   readonly hasGeolocation: boolean;
 }

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
@@ -73,7 +73,7 @@ export class PostCaptureTabComponent implements OnInit {
   }
 
   fetchPostCaptures$() {
-    return this.diaBackendAssetRepository.fetchPostCapturePagination$().pipe(
+    return this.diaBackendAssetRepository.fetchPostCaptures$().pipe(
       first(),
       map(pagination => pagination.results),
       map(assets => assets.filter(asset => asset.source_transaction)),

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
@@ -1,25 +1,23 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { IPageInfo } from 'ngx-virtual-scroller';
-import { BehaviorSubject, combineLatest, of, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, defer } from 'rxjs';
 import {
   catchError,
-  concatMap,
   distinctUntilChanged,
   filter,
   first,
   map,
   startWith,
-  switchMap,
+  switchMapTo,
   tap,
 } from 'rxjs/operators';
 import {
   DiaBackendAsset,
   DiaBackendAssetRepository,
 } from '../../../shared/services/dia-backend/asset/dia-backend-asset-repository.service';
-import { Pagination } from '../../../shared/services/dia-backend/pagination/pagination';
 import { NetworkService } from '../../../shared/services/network/network.service';
+import { OldDefaultInformationName } from '../../../shared/services/repositories/proof/old-proof-adapter';
 import { isNonNullable, VOID$ } from '../../../utils/rx-operators/rx-operators';
 
 @UntilDestroy({ checkProperties: true })
@@ -32,40 +30,23 @@ export class PostCaptureTabComponent implements OnInit {
   @Input('focus') set focus(focus: boolean) {
     this._focus$.next(focus);
   }
+
   private readonly _focus$ = new BehaviorSubject(false);
-  private readonly paginationSize = 10;
-  private readonly _postCaptures$ = new BehaviorSubject<DiaBackendAsset[]>([]);
+
+  readonly focus$ = this._focus$.pipe(distinctUntilChanged());
+
   // tslint:disable-next-line: rxjs-no-explicit-generics
-  private readonly _pagination$ = new BehaviorSubject<
-    Pagination<DiaBackendAsset> | undefined
+  private readonly _postCaptures$ = new BehaviorSubject<
+    PostCaptureItem[] | undefined
   >(undefined);
-  // tslint:disable-next-line: rxjs-no-explicit-generics
-  private readonly _loadNextPageEvent$ = new Subject<IPageInfo>();
-  private readonly _isLoadingNextPage$ = new BehaviorSubject(false);
-  readonly focus$ = this._focus$.asObservable().pipe(distinctUntilChanged());
-  readonly postCaptures$ = this._postCaptures$
-    .asObservable()
-    .pipe(distinctUntilChanged());
-  readonly pagination$ = this._pagination$
-    .asObservable()
-    .pipe(distinctUntilChanged());
-  readonly loadNextPageEvent$ = this._loadNextPageEvent$.asObservable().pipe(
+
+  readonly postCaptures$ = this._postCaptures$.pipe(
     isNonNullable(),
-    concatMap(event =>
-      combineLatest([of(event), this.postCaptures$, this.pagination$]).pipe(
-        first()
-      )
-    ),
-    filter(
-      ([event, postCaptures, pagination]) =>
-        event.endIndex === postCaptures.length - 1 && !!pagination?.next
-    ),
-    map(([e, p, pagination]) => pagination)
+    distinctUntilChanged()
   );
-  readonly isLoadingNextPage$ = this._isLoadingNextPage$
-    .asObservable()
-    .pipe(distinctUntilChanged());
+
   readonly networkConnected$ = this.networkService.connected$;
+
   readonly onDidNavigate$ = this.router.events.pipe(
     filter(event => event instanceof NavigationEnd && event?.url === '/home'),
     startWith(undefined)
@@ -80,63 +61,43 @@ export class PostCaptureTabComponent implements OnInit {
   ngOnInit() {
     combineLatest([this.focus$, this.onDidNavigate$])
       .pipe(
-        filter(([focus, _]) => !!focus),
-        switchMap(() =>
-          this.fetchPostCaptures$().pipe(
-            tap(postCapture => this._postCaptures$.next(postCapture)),
-            concatMap(() => this.loadNextPageEventHandler$())
-          )
-        ),
+        filter(([focus]) => focus),
+        switchMapTo(defer(() => this.fetchPostCaptures$())),
+        catchError(err => {
+          console.error(err);
+          return VOID$;
+        }),
         untilDestroyed(this)
       )
       .subscribe();
   }
 
-  fetchPostCaptures$(overrideUrl?: string) {
-    return this.diaBackendAssetRepository
-      .fetchPostCapturePagination$(this.paginationSize, overrideUrl)
-      .pipe(
-        tap(pagination => this._pagination$.next(pagination)),
-        map(pagination => pagination.results),
-        map(assets => assets.filter(asset => !!asset.source_transaction)),
-        catchError(err => {
-          console.error(err);
-          return of([]);
-        })
-      );
-  }
-
-  loadNextPage(event: IPageInfo) {
-    this._loadNextPageEvent$.next(event);
+  fetchPostCaptures$() {
+    return this.diaBackendAssetRepository.fetchPostCapturePagination$().pipe(
+      first(),
+      map(pagination => pagination.results),
+      map(assets => assets.filter(asset => asset.source_transaction)),
+      map(assets =>
+        assets.map<PostCaptureItem>(asset => ({
+          oldProofHash: asset.proof_hash,
+          thumbnailUrl: asset.asset_file_thumbnail,
+          hasGeolocation: !!asset.information.information?.find(
+            info => info.name === OldDefaultInformationName.GEOLOCATION_LATITUDE
+          ),
+        }))
+      ),
+      tap(postCapture => this._postCaptures$.next(postCapture))
+    );
   }
 
   // tslint:disable-next-line: prefer-function-over-method
   trackPostCapture(_: number, item: DiaBackendAsset) {
     return item.id;
   }
+}
 
-  private concatPostCaptures(postCaptures: DiaBackendAsset[]) {
-    this._postCaptures$.next(this._postCaptures$.value.concat(postCaptures));
-  }
-
-  private loadNextPageEventHandler$() {
-    const loadData$ = this.pagination$.pipe(
-      first(),
-      concatMap(pagination => this.fetchPostCaptures$(pagination?.next)),
-      tap(newPostCaptures => this.concatPostCaptures(newPostCaptures))
-    );
-    return this.loadNextPageEvent$.pipe(
-      concatMap(() => this.isLoadingNextPage$.pipe(first())),
-      filter(isLoadingNextPage => !isLoadingNextPage),
-      tap(() => this._isLoadingNextPage$.next(true)),
-      concatMap(() => loadData$),
-      tap(() => this._isLoadingNextPage$.next(false)),
-      catchError(err => {
-        this._isLoadingNextPage$.next(false);
-        console.error(err);
-        return VOID$;
-      }),
-      untilDestroyed(this)
-    );
-  }
+interface PostCaptureItem {
+  readonly oldProofHash: string;
+  readonly thumbnailUrl: string;
+  readonly hasGeolocation: boolean;
 }


### PR DESCRIPTION
See #555.

- Remove virtual-scroll on PostCapture tab.
- Update the layout on PostCapture tab to grid layout.
- Fetch all PostCaptures on focusing on PostCapture tab.
- Load PostCapture thumbnails lazily with `ion-img`.
- Implement a standalone `PostCaptureDetailsPage`, which cause a heavy code duplicate to the existent `CaptureDetailsPage`. However, as the UI and the data model of both Captures and PostCaptures will be changed significantly in the near future, this could be a temporary solution for easy adjustment.