### PR TITLE
Remove geolocation icon on PostCaptureTabComponent.

### DIFF
--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.html
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.html
@@ -3,11 +3,6 @@
     *ngFor="let postCapture of postCaptures$ | async; trackBy: trackPostCapture"
     [routerLink]="['post-capture-details', { id: postCapture.id }]"
   >
-    <ion-icon
-      *ngIf="postCapture.hasGeolocation"
-      src="/assets/icon/location.svg"
-      class="located"
-    ></ion-icon>
     <ion-img [src]="postCapture.thumbnailUrl"></ion-img>
   </mat-grid-tile>
 </mat-grid-list>

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.scss
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.scss
@@ -12,17 +12,4 @@ mat-grid-tile {
     overflow: hidden;
     border-radius: 4px;
   }
-
-  ion-icon {
-    color: white;
-    z-index: 10;
-  }
-
-  ion-icon.located {
-    position: absolute;
-    bottom: 9px;
-    left: 5px;
-    font-size: 13px;
-    opacity: 30%;
-  }
 }

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
@@ -17,7 +17,6 @@ import {
   DiaBackendAssetRepository,
 } from '../../../shared/services/dia-backend/asset/dia-backend-asset-repository.service';
 import { NetworkService } from '../../../shared/services/network/network.service';
-import { OldDefaultInformationName } from '../../../shared/services/repositories/proof/old-proof-adapter';
 import { isNonNullable, VOID$ } from '../../../utils/rx-operators/rx-operators';
 
 @UntilDestroy({ checkProperties: true })
@@ -81,9 +80,6 @@ export class PostCaptureTabComponent implements OnInit {
         assets.map<PostCaptureItem>(asset => ({
           id: asset.id,
           thumbnailUrl: asset.asset_file_thumbnail,
-          hasGeolocation: !!asset.information.information?.find(
-            info => info.name === OldDefaultInformationName.GEOLOCATION_LATITUDE
-          ),
         }))
       ),
       tap(postCapture => this._postCaptures$.next(postCapture))
@@ -99,5 +95,4 @@ export class PostCaptureTabComponent implements OnInit {
 interface PostCaptureItem {
   readonly id: string;
   readonly thumbnailUrl: string;
-  readonly hasGeolocation: boolean;
 }


### PR DESCRIPTION
According to the feedback from @tammyyang on Sprint and mid-sprint demo, we do not need to show the geolocation icon on PostCapture tab.