### PR TITLE
Prefetch partial PostCaptures on PostCapture tab init

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -135,6 +135,7 @@ jobs:
           api-private-key: ${{ secrets.APPSTORE_PRIVATE_KEY }}
 
       - name: Save iOS build number
+        if: steps.version_check.outputs.changed == 'true'
         run: |
           echo ${{ steps.current-time.outputs.formattedTime }} > build/ios-build-number.txt
 

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.html
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.html
@@ -3,6 +3,6 @@
     *ngFor="let postCapture of postCaptures$ | async; trackBy: trackPostCapture"
     [routerLink]="['post-capture-details', { id: postCapture.id }]"
   >
-    <ion-img [src]="postCapture.thumbnailUrl"></ion-img>
+    <img [src]="postCapture.thumbnailUrl" />
   </mat-grid-tile>
 </mat-grid-list>

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.scss
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.scss
@@ -4,7 +4,7 @@
 }
 
 mat-grid-tile {
-  ion-img {
+  img {
     width: 100%;
     height: 100%;
     object-fit: cover;

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
@@ -69,10 +69,12 @@ export class PostCaptureTabComponent implements OnInit {
         untilDestroyed(this)
       )
       .subscribe();
+
+    this.fetchPostCaptures$(9).pipe(first(), untilDestroyed(this)).subscribe();
   }
 
-  fetchPostCaptures$() {
-    return this.diaBackendAssetRepository.fetchPostCaptures$().pipe(
+  fetchPostCaptures$(pageSize?: number) {
+    return this.diaBackendAssetRepository.fetchPostCaptures$(pageSize).pipe(
       first(),
       map(pagination => pagination.results),
       map(assets => assets.filter(asset => asset.source_transaction)),

--- a/src/app/shared/services/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/shared/services/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -124,19 +124,19 @@ export class DiaBackendAssetRepository {
       concatMap(headers => {
         let params = new HttpParams();
 
-        if (offset) {
+        if (offset !== undefined) {
           params = params.set('offset', `${offset}`);
         }
-        if (limit) {
+        if (limit !== undefined) {
           params = params.set('limit', `${limit}`);
         }
-        if (isOriginalOwner) {
+        if (isOriginalOwner !== undefined) {
           params = params.set('is_original_owner', `${isOriginalOwner}`);
         }
-        if (orderBy) {
+        if (orderBy !== undefined) {
           params = params.set('order_by', `${orderBy}`);
         }
-        if (proofHash) {
+        if (proofHash !== undefined) {
           params = params.set('proof_hash', `${proofHash}`);
         }
 


### PR DESCRIPTION
According to [the discussion on Slack](https://dt42-numbers.slack.com/archives/CS29L7Z5H/p1615519385004100?thread_ts=1615515545.002100&cid=CS29L7Z5H), prefetch 9 PostCaptures on the tab initialization.

This PR has been tested on Brave browser and Exodus 1 with dev site.