### PR TITLE
Get Thumbnail src with URI instead of DataURL

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "material-design-icons-iconfont": "^6.1.0",
     "merge-images": "^2.0.0",
     "rxjs": "~6.6.3",
+    "safe-pipe": "^1.0.3",
     "tslib": "^2.0.1",
     "zone.js": "~0.10.2"
   },

--- a/src/app/features/home/capture-tab/capture-tab.component.html
+++ b/src/app/features/home/capture-tab/capture-tab.component.html
@@ -74,7 +74,7 @@
           src="/assets/icon/location.svg"
           class="located"
         ></ion-icon>
-        <img [src]="captureItem.thumbnailUrl" />
+        <img [src]="captureItem.thumbnailUrl | safe: 'url'" />
       </mat-grid-tile>
     </mat-grid-list>
   </ng-container>

--- a/src/app/shared/services/image-store/image-store.service.spec.ts
+++ b/src/app/shared/services/image-store/image-store.service.spec.ts
@@ -47,7 +47,7 @@ describe('ImageStore', () => {
 
   it('should delete file with index and thumbnail', async () => {
     const index = await store.write(FILE, MIME_TYPE);
-    await store.readThumbnail(index, MIME_TYPE);
+    await store.getThumbnailUrl(index, MIME_TYPE);
 
     await store.delete(index);
 
@@ -101,7 +101,7 @@ describe('ImageStore', () => {
 
   it('should read thumbnail', async () => {
     const index = await store.write(FILE, MIME_TYPE);
-    const thumbnailFile = await store.readThumbnail(index, MIME_TYPE);
+    const thumbnailFile = await store.getThumbnailUrl(index, MIME_TYPE);
     expect(thumbnailFile).toBeTruthy();
   });
 

--- a/src/app/shared/services/image-store/image-store.service.ts
+++ b/src/app/shared/services/image-store/image-store.service.ts
@@ -131,6 +131,8 @@ export class ImageStore {
 
     if (thumbnail) {
       if (Capacitor.isNative) {
+        // Use native URI to reduce memory usage during serialization between
+        // base64.
         return Capacitor.convertFileSrc(
           await this.getUri(thumbnail.thumbnailIndex)
         );

--- a/src/app/shared/services/image-store/image-store.service.ts
+++ b/src/app/shared/services/image-store/image-store.service.ts
@@ -1,11 +1,16 @@
 import { Inject, Injectable } from '@angular/core';
-import { FilesystemDirectory, FilesystemPlugin } from '@capacitor/core';
+import {
+  Capacitor,
+  FilesystemDirectory,
+  FilesystemPlugin,
+} from '@capacitor/core';
 import { Mutex } from 'async-mutex';
 import ImageBlobReduce from 'image-blob-reduce';
 import { FILESYSTEM_PLUGIN } from '../../../shared/core/capacitor-plugins/capacitor-plugins.module';
 import { sha256WithBase64 } from '../../../utils/crypto/crypto';
 import { base64ToBlob, blobToBase64 } from '../../../utils/encoding/encoding';
 import { MimeType, toExtension } from '../../../utils/mime-type';
+import { toDataUrl } from '../../../utils/url';
 import { Database } from '../database/database.service';
 import { OnConflictStrategy, Tuple } from '../database/table/table';
 
@@ -121,13 +126,18 @@ export class ImageStore {
     return result.files.includes(`${index}.${extension}`);
   }
 
-  async readThumbnail(index: string, mimeType: MimeType) {
+  async getThumbnailUrl(index: string, mimeType: MimeType) {
     const thumbnail = await this.getThumbnail(index);
 
     if (thumbnail) {
-      return this.read(thumbnail.thumbnailIndex);
+      if (Capacitor.isNative) {
+        return Capacitor.convertFileSrc(
+          await this.getUri(thumbnail.thumbnailIndex)
+        );
+      }
+      return toDataUrl(await this.read(thumbnail.thumbnailIndex), mimeType);
     }
-    return this.setThumbnail(index, mimeType);
+    return toDataUrl(await this.setThumbnail(index, mimeType), mimeType);
   }
 
   private async setThumbnail(index: string, mimeType: MimeType) {
@@ -136,7 +146,7 @@ export class ImageStore {
   }
 
   private async makeThumbnail(index: string, mimeType: MimeType) {
-    const thumbnailSize = 200;
+    const thumbnailSize = 100;
     const blob = await base64ToBlob(await this.read(index), mimeType);
     const thumbnailBlob = await imageBlobReduce.toBlob(blob, {
       max: thumbnailSize,

--- a/src/app/shared/services/repositories/proof/proof.ts
+++ b/src/app/shared/services/repositories/proof/proof.ts
@@ -1,7 +1,6 @@
 import { sha256WithString } from '../../../../utils/crypto/crypto';
 import { sortObjectDeeplyByKey } from '../../../../utils/immutable/immutable';
 import { MimeType } from '../../../../utils/mime-type';
-import { toDataUrl } from '../../../../utils/url';
 import { Tuple } from '../../database/table/table';
 import {
   ImageStore,
@@ -76,11 +75,7 @@ export class Proof {
       return undefined;
     }
     const [index, assetMeta] = imageAsset;
-    const base64 = await this.imageStore.readThumbnail(
-      index,
-      assetMeta.mimeType
-    );
-    return toDataUrl(base64, assetMeta.mimeType);
+    return this.imageStore.getThumbnailUrl(index, assetMeta.mimeType);
   }
 
   getFactValue(id: string) {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -4,6 +4,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 import { TranslocoModule } from '@ngneat/transloco';
+import { SafePipeModule } from 'safe-pipe';
 import { CapacitorPluginsModule } from './core/capacitor-plugins/capacitor-plugins.module';
 import { MaterialModule } from './core/material/material.module';
 import { MigratingDialogComponent } from './core/migrating-dialog/migrating-dialog.component';
@@ -16,6 +17,7 @@ import { MigratingDialogComponent } from './core/migrating-dialog/migrating-dial
     FormsModule,
     ReactiveFormsModule,
     HttpClientModule,
+    SafePipeModule,
     TranslocoModule,
     MaterialModule,
     CapacitorPluginsModule,
@@ -25,6 +27,7 @@ import { MigratingDialogComponent } from './core/migrating-dialog/migrating-dial
     IonicModule,
     FormsModule,
     ReactiveFormsModule,
+    SafePipeModule,
     TranslocoModule,
     MaterialModule,
   ],


### PR DESCRIPTION
Use `Filesystem.getUri()` method in Capacitor plugin to handle thumbnail request. The method does not work in browser, and thus need to check the environment before request URI. 

By doing so, we do not need to serialize/deserialize the image file to base64, which reduces some memory usage.

This PR has been tested on Brave browser and Exodus 1.