### PR TITLE
Implement memory cache for PostCaptures.

### DIFF
--- a/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.html
+++ b/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.html
@@ -9,7 +9,7 @@
 </mat-toolbar>
 
 <mat-list>
-  <img [attr.src]="(diaBackendAsset$ | async)?.asset_file" />
+  <ion-img [attr.src]="imageSrc$ | async"></ion-img>
   <mat-list-item>
     <mat-icon mat-list-icon>person</mat-icon>
     <div mat-line>

--- a/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.ts
@@ -5,7 +5,7 @@ import { ActionSheetController } from '@ionic/angular';
 import { TranslocoService } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { zip } from 'rxjs';
-import { map, shareReplay, switchMap } from 'rxjs/operators';
+import { first, map, shareReplay, switchMap } from 'rxjs/operators';
 import {
   DiaBackendAsset,
   DiaBackendAssetRepository,
@@ -27,7 +27,16 @@ export class PostCaptureDetailsPage {
   readonly diaBackendAsset$ = this.route.paramMap.pipe(
     map(params => params.get('id')),
     isNonNullable(),
-    switchMap(id => this.diaBackendAssetRepository.fetchById$(id)),
+    switchMap(id => this.diaBackendAssetRepository.getPostCaptureById$(id)),
+    shareReplay({ bufferSize: 1, refCount: true })
+  );
+
+  readonly imageSrc$ = this.diaBackendAsset$.pipe(
+    switchMap(asset =>
+      this.diaBackendAssetRepository.getAndCachePostCaptureImage$(asset)
+    ),
+    first(),
+    map(blob => URL.createObjectURL(blob)),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.ts
@@ -21,7 +21,7 @@ export class PostCaptureTabComponent {
     switchMap(isConnected =>
       iif(
         () => isConnected,
-        this.diaBackendAssetRepository.getPostCaptures$().pipe(
+        this.diaBackendAssetRepository.postCaptures$.pipe(
           pluck('results'),
           map(assets => assets.filter(a => a.source_transaction))
         )

--- a/src/app/shared/services/migration/migration.service.ts
+++ b/src/app/shared/services/migration/migration.service.ts
@@ -143,8 +143,7 @@ export class MigrationService {
   }
 
   private async fetchAllPostCaptures() {
-    return this.diaBackendAssetRepository
-      .getPostCaptures$()
+    return this.diaBackendAssetRepository.postCaptures$
       .pipe(first(), pluck('results'))
       .toPromise();
   }


### PR DESCRIPTION
See #554.

According to the discussion on mid-sprint kickoff, implement in-memory cache for PostCaptures to provide better UX.

- Cache PostCapture list response in memory.
- Cache PostCapture `asset_file` in memory.
    - Possible thrashing with high `asset_file` quantity.

This is NOT an ideal cache implementation as we should build a safer and more structural LRU cache by leveraging declarative caching tool kits, such as `ngsw`. However, we do not have enought time for now.

Tested on Brave browser and Exodus 1.