### PR TITLE
Make network status bar position consistent

### DIFF
--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.html
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.html
@@ -1,6 +1,3 @@
-<p *ngIf="(networkConnected$ | async) === false" class="network-status">
-  {{ 'message.networkNotConnected' | transloco }}
-</p>
 <div class="segments" [ngSwitch]="categories">
   <ion-segment mode="ios" [(ngModel)]="categories">
     <ion-segment-button value="Photo" checked>
@@ -13,6 +10,9 @@
       ></ion-icon>
     </ion-segment-button>
   </ion-segment>
+  <p *ngIf="(networkConnected$ | async) === false" class="network-status">
+    {{ 'message.networkNotConnected' | transloco }}
+  </p>
   <div class="post-captures" *ngSwitchCase="'Photo'">
     <mat-grid-list cols="3" gutterSize="8px">
       <mat-grid-tile
@@ -27,7 +27,7 @@
     </mat-grid-list>
   </div>
 
-  <div class="series-wrapper" *ngSwitchCase="'Series'">
+  <div *ngSwitchCase="'Series'">
     <app-series-card routerLink="series"></app-series-card>
     <app-series-card routerLink="series"></app-series-card>
     <app-series-card routerLink="series"></app-series-card>

--- a/src/app/features/home/post-capture-tab/post-capture-tab.component.scss
+++ b/src/app/features/home/post-capture-tab/post-capture-tab.component.scss
@@ -15,19 +15,19 @@
 
 .segments {
   display: flex;
-  padding: 8px;
   flex-direction: column;
   height: 100%;
 }
 
 ion-segment {
   width: 80%;
-  margin: 0 auto 16px;
+  margin: 8px auto 16px;
   flex-shrink: 0;
 }
 
 .post-captures {
   overflow: auto;
+  padding: 8px;
 }
 
 mat-grid-tile {


### PR DESCRIPTION
According to the discussion of demo on 03/31/2021, we need to move the network status bar position below `ion-segment` on `PostCaptureTabComponent`.

Tested on Brave browser and Exodus 1.