### PR TITLE
Fix: refreshPostCaptures not work with local cache.

### DIFF
--- a/src/app/shared/services/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/shared/services/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -81,12 +81,10 @@ export class DiaBackendAssetRepository {
           limit: count,
         })
       ),
-      tap(response => this.postCapturesCache$.next(response))
+      tap(response => this.postCapturesCache$.next(response)),
+      repeatWhen(() => this.postCapturesUpdated$)
     )
-  ).pipe(
-    distinctUntilChanged(),
-    repeatWhen(() => this.postCapturesUpdated$)
-  );
+  ).pipe(distinctUntilChanged());
 
   constructor(
     private readonly httpClient: HttpClient,


### PR DESCRIPTION
It seems that `repeatWhen` does not work with endless observable.

Tested on Brave browser and Exodus 1.