### PR TITLE
Integrate Sentry.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ Re-release to update Android `versionCode`.
 - Support video view. #627
 - Re-add series view.
 
+## 0.27.12 - 2021-04-27
+
+### Fixed
+
+- Show IPFS supporting files if the URL is valid.
+
+### Changed
+
+- Move the order of optional menus on PostCapture details page.
+
 ## 0.27.11 - 2021-04-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "@ngx-formly/core": "^5.10.15",
         "@ngx-formly/material": "^5.10.15",
         "@ngx-formly/schematics": "^5.10.15",
+        "@sentry/angular": "^6.3.1",
+        "@sentry/tracing": "^6.3.1",
         "async-mutex": "^0.3.1",
         "compressorjs": "^1.0.7",
         "immutable": "^4.0.0-rc.12",
@@ -3048,6 +3050,151 @@
         "npm": "^6.11.0 || ^7.5.6",
         "yarn": ">= 1.13.0"
       }
+    },
+    "node_modules/@sentry/angular": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/angular/-/angular-6.3.1.tgz",
+      "integrity": "sha512-eExQ8Ic2UXmrBkPOc42pcMZAxVG+CEkByvFwHANeV7ihaeGwGn92mLjVoicVr/h9tR5cfmkKJLNoqIh3STfh0Q==",
+      "dependencies": {
+        "@sentry/browser": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+        "rxjs": "^6.6.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "@angular/common": "10.x || 11.x",
+        "@angular/core": "10.x || 11.x",
+        "@angular/router": "10.x || 11.x"
+      }
+    },
+    "node_modules/@sentry/angular/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/browser": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.1.tgz",
+      "integrity": "sha512-Ri4tYsyuJIeLQnvQUqbpGzailUYpbjFSYM0+yEM63gPsjiXdg+W8yKHluA6cs6FLWVN3oWfwHW7Kd61echlGuw==",
+      "dependencies": {
+        "@sentry/core": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-aVuvVbaehGeN86jZlLDGGkhEtprdOtB6lvYLfGy40Dj1Tkh2mGWE550QsRXAXAqYvQzIYwQR23r6m3o8FujgVg==",
+      "dependencies": {
+        "@sentry/hub": "6.3.1",
+        "@sentry/minimal": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/hub": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.1.tgz",
+      "integrity": "sha512-2er+OeVlsdVZkhl9kXQAANwgjwoCdM1etK2iFuhzX8xkMaJlAuZLyQInv2U1BbXBlIfWjvzRM8B95hCWvVrR3Q==",
+      "dependencies": {
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/minimal": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.1.tgz",
+      "integrity": "sha512-0eN9S7HvXsCQEjX/qXHTMgvSb3mwrnZEWS9Qz/Bz5ig9pEGXKgJ1om5NTTHVHhXqd3wFCjdvIo6slufLHoCtSw==",
+      "dependencies": {
+        "@sentry/hub": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/minimal/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.3.1.tgz",
+      "integrity": "sha512-qveDmoWsXy9qLEblZJwJ1OU/zZRlEd/q7Jhd0Hnwlob8Ci96huABEbYyGdJs18BKVHEFU3gSdVfvrikUE/W17g==",
+      "dependencies": {
+        "@sentry/hub": "6.3.1",
+        "@sentry/minimal": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/tracing/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sentry/types": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.1.tgz",
+      "integrity": "sha512-BEBn8JX1yaooCAuonbaMci9z0RjwwMbQ3Eny/eyDdd+rjXprZCZaStZnCvSThbNBqAJ8YaUqY2YBMnEwJxarAw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.1.tgz",
+      "integrity": "sha512-cdtl/QWC9FtinAuW3w8QfvSfh/Q9ui5vwvjzVHiS1ga/U38edi2XX+cttY39ZYwz0SQG99cE10GOIhd1p7/mAA==",
+      "dependencies": {
+        "@sentry/types": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@stencil/core": {
       "version": "2.5.2",
@@ -26937,6 +27084,136 @@
         "pacote": "11.2.4",
         "semver": "7.3.4",
         "semver-intersect": "1.4.0"
+      }
+    },
+    "@sentry/angular": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/angular/-/angular-6.3.1.tgz",
+      "integrity": "sha512-eExQ8Ic2UXmrBkPOc42pcMZAxVG+CEkByvFwHANeV7ihaeGwGn92mLjVoicVr/h9tR5cfmkKJLNoqIh3STfh0Q==",
+      "requires": {
+        "@sentry/browser": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+        "rxjs": "^6.6.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/browser": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.3.1.tgz",
+      "integrity": "sha512-Ri4tYsyuJIeLQnvQUqbpGzailUYpbjFSYM0+yEM63gPsjiXdg+W8yKHluA6cs6FLWVN3oWfwHW7Kd61echlGuw==",
+      "requires": {
+        "@sentry/core": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-aVuvVbaehGeN86jZlLDGGkhEtprdOtB6lvYLfGy40Dj1Tkh2mGWE550QsRXAXAqYvQzIYwQR23r6m3o8FujgVg==",
+      "requires": {
+        "@sentry/hub": "6.3.1",
+        "@sentry/minimal": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/hub": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.3.1.tgz",
+      "integrity": "sha512-2er+OeVlsdVZkhl9kXQAANwgjwoCdM1etK2iFuhzX8xkMaJlAuZLyQInv2U1BbXBlIfWjvzRM8B95hCWvVrR3Q==",
+      "requires": {
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/minimal": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.3.1.tgz",
+      "integrity": "sha512-0eN9S7HvXsCQEjX/qXHTMgvSb3mwrnZEWS9Qz/Bz5ig9pEGXKgJ1om5NTTHVHhXqd3wFCjdvIo6slufLHoCtSw==",
+      "requires": {
+        "@sentry/hub": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/tracing": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.3.1.tgz",
+      "integrity": "sha512-qveDmoWsXy9qLEblZJwJ1OU/zZRlEd/q7Jhd0Hnwlob8Ci96huABEbYyGdJs18BKVHEFU3gSdVfvrikUE/W17g==",
+      "requires": {
+        "@sentry/hub": "6.3.1",
+        "@sentry/minimal": "6.3.1",
+        "@sentry/types": "6.3.1",
+        "@sentry/utils": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@sentry/types": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.3.1.tgz",
+      "integrity": "sha512-BEBn8JX1yaooCAuonbaMci9z0RjwwMbQ3Eny/eyDdd+rjXprZCZaStZnCvSThbNBqAJ8YaUqY2YBMnEwJxarAw=="
+    },
+    "@sentry/utils": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.3.1.tgz",
+      "integrity": "sha512-cdtl/QWC9FtinAuW3w8QfvSfh/Q9ui5vwvjzVHiS1ga/U38edi2XX+cttY39ZYwz0SQG99cE10GOIhd1p7/mAA==",
+      "requires": {
+        "@sentry/types": "6.3.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "@stencil/core": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "@ngx-formly/core": "^5.10.15",
     "@ngx-formly/material": "^5.10.15",
     "@ngx-formly/schematics": "^5.10.15",
+    "@sentry/angular": "^6.3.1",
+    "@sentry/tracing": "^6.3.1",
     "async-mutex": "^0.3.1",
     "compressorjs": "^1.0.7",
     "immutable": "^4.0.0-rc.12",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { Plugins } from '@capacitor/core';
 import { Platform } from '@ionic/angular';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { catchError, concatMap } from 'rxjs/operators';
+import { ErrorReportService } from './shared/modules/error/error-report.service';
 import { ErrorService } from './shared/modules/error/error.service';
 import { CameraService } from './shared/services/camera/camera.service';
 import { CaptureService } from './shared/services/capture/capture.service';
@@ -37,6 +38,7 @@ export class AppComponent {
     private readonly captureService: CaptureService,
     private readonly cameraService: CameraService,
     private readonly errorService: ErrorService,
+    errorReportService: ErrorReportService,
     notificationService: NotificationService,
     pushNotificationService: PushNotificationService,
     langaugeService: LanguageService,
@@ -44,6 +46,7 @@ export class AppComponent {
     diaBackendNotificationService: DiaBackendNotificationService,
     uploadService: DiaBackendAssetUploadingService
   ) {
+    errorReportService.initialize$.pipe(untilDestroyed(this)).subscribe();
     notificationService.requestPermission();
     pushNotificationService.register();
     langaugeService.initialize();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,7 @@ import { FormlyMaterialModule } from '@ngx-formly/material';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { TranslocoRootModule } from './shared/core/transloco/transloco-root.module';
+import { ErrorModule } from './shared/modules/error/error.module';
 import { SharedModule } from './shared/shared.module';
 
 @NgModule({
@@ -23,6 +24,7 @@ import { SharedModule } from './shared/shared.module';
     TranslocoRootModule,
     FormlyModule.forRoot({ extras: { lazyRender: true } }),
     FormlyMaterialModule,
+    ErrorModule.forRoot(),
   ],
   providers: [
     {

--- a/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.ts
+++ b/src/app/features/home/post-capture-tab/post-capture-details/post-capture-details.page.ts
@@ -98,14 +98,21 @@ export class PostCaptureDetailsPage {
               viewSupportingVideoOnIpfs,
             ],
           ]) => {
-            const buttons: ActionSheetButton[] = [
-              {
-                text: shareCapture,
+            const buttons: ActionSheetButton[] = [];
+            if (diaBackendAsset.supporting_file) {
+              buttons.push({
+                text: viewSupportingVideoOnIpfs,
                 handler: () => {
-                  this.share();
+                  this.openIpfsSupportingVideo();
                 },
+              });
+            }
+            buttons.push({
+              text: shareCapture,
+              handler: () => {
+                this.share();
               },
-            ];
+            });
             if (diaBackendAsset.source_type === 'store') {
               buttons.push({
                 text: viewOnCaptureClub,
@@ -114,20 +121,12 @@ export class PostCaptureDetailsPage {
                 },
               });
             }
-            buttons.push(
-              {
-                text: viewBlockchainCertificate,
-                handler: () => {
-                  this.openCertificate();
-                },
+            buttons.push({
+              text: viewBlockchainCertificate,
+              handler: () => {
+                this.openCertificate();
               },
-              {
-                text: viewSupportingVideoOnIpfs,
-                handler: () => {
-                  this.openIpfsSupportingVideo();
-                },
-              }
-            );
+            });
             return this.actionSheetController.create({ buttons });
           }
         ),

--- a/src/app/features/settings/settings.page.html
+++ b/src/app/features/settings/settings.page.html
@@ -13,6 +13,7 @@
       <ion-select
         [value]="currentLanguageKey$ | async"
         (ionChange)="setCurrentLanguage($event)"
+        slot="end"
       >
         <ion-select-option
           *ngFor="let language of langauges | keyvalue"
@@ -25,7 +26,11 @@
     <ion-item>
       <ion-icon name="bug" slot="start"></ion-icon>
       <ion-label>{{ t('errorReport') }}</ion-label>
-      <ion-toggle></ion-toggle>
+      <ion-toggle
+        [checked]="errorReportEnabled$ | async"
+        (ionChange)="setErrorReportEnabled($event)"
+        slot="end"
+      ></ion-toggle>
     </ion-item>
   </ion-list>
 </ion-content>

--- a/src/app/features/settings/settings.page.html
+++ b/src/app/features/settings/settings.page.html
@@ -5,22 +5,27 @@
   <span>{{ t('settings') }}</span>
 </mat-toolbar>
 
-<div class="page-content">
-  <mat-list *transloco="let t">
-    <mat-list-item>
-      <mat-icon mat-list-icon>language</mat-icon>
-      <div mat-line>{{ t('languages') }}</div>
-      <mat-select
+<ion-content *transloco="let t">
+  <ion-list lines="none">
+    <ion-item>
+      <ion-icon name="language" slot="start"></ion-icon>
+      <ion-label>{{ t('languages') }}</ion-label>
+      <ion-select
         [value]="currentLanguageKey$ | async"
-        (selectionChange)="setCurrentLanguage($event.value)"
+        (ionChange)="setCurrentLanguage($event)"
       >
-        <mat-option
+        <ion-select-option
           *ngFor="let language of langauges | keyvalue"
           [value]="language.key"
         >
           {{ language.value }}
-        </mat-option>
-      </mat-select>
-    </mat-list-item>
-  </mat-list>
-</div>
+        </ion-select-option>
+      </ion-select>
+    </ion-item>
+    <ion-item>
+      <ion-icon name="bug" slot="start"></ion-icon>
+      <ion-label>{{ t('errorReport') }}</ion-label>
+      <ion-toggle></ion-toggle>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/features/settings/settings.page.scss
+++ b/src/app/features/settings/settings.page.scss
@@ -4,6 +4,6 @@ mat-toolbar {
   }
 }
 
-mat-select {
-  width: 50%;
+ion-select {
+  width: auto;
 }

--- a/src/app/features/settings/settings.page.ts
+++ b/src/app/features/settings/settings.page.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { UntilDestroy } from '@ngneat/until-destroy';
+import { ErrorReportService } from '../../shared/modules/error/error-report.service';
 import { LanguageService } from '../../shared/services/language/language.service';
 
 @UntilDestroy({ checkProperties: true })
@@ -10,12 +11,23 @@ import { LanguageService } from '../../shared/services/language/language.service
 })
 export class SettingsPage {
   readonly langauges = this.languageService.languages;
+
   readonly currentLanguageKey$ = this.languageService.currentLanguageKey$;
 
-  constructor(private readonly languageService: LanguageService) {}
+  readonly errorReportEnabled$ = this.errorReportService.enabled$;
+
+  constructor(
+    private readonly languageService: LanguageService,
+    private readonly errorReportService: ErrorReportService
+  ) {}
 
   async setCurrentLanguage(event: Event) {
     const customEvent = event as CustomEvent<HTMLIonSelectElement>;
     return this.languageService.setCurrentLanguage(customEvent.detail.value);
+  }
+
+  async setErrorReportEnabled(event: Event) {
+    const customEvent = event as CustomEvent<HTMLIonToggleElement>;
+    return this.errorReportService.setEnabled(customEvent.detail.checked);
   }
 }

--- a/src/app/features/settings/settings.page.ts
+++ b/src/app/features/settings/settings.page.ts
@@ -14,7 +14,8 @@ export class SettingsPage {
 
   constructor(private readonly languageService: LanguageService) {}
 
-  async setCurrentLanguage(languageKey: string) {
-    return this.languageService.setCurrentLanguage(languageKey);
+  async setCurrentLanguage(event: Event) {
+    const customEvent = event as CustomEvent<HTMLIonSelectElement>;
+    return this.languageService.setCurrentLanguage(customEvent.detail.value);
   }
 }

--- a/src/app/shared/modules/error/error-report.service.spec.ts
+++ b/src/app/shared/modules/error/error-report.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ErrorReportService } from './error-report.service';
+
+describe('ErrorReportService', () => {
+  let service: ErrorReportService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ErrorReportService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/modules/error/error-report.service.spec.ts
+++ b/src/app/shared/modules/error/error-report.service.spec.ts
@@ -1,12 +1,12 @@
 import { TestBed } from '@angular/core/testing';
-
+import { SharedTestingModule } from '../../shared-testing.module';
 import { ErrorReportService } from './error-report.service';
 
 describe('ErrorReportService', () => {
   let service: ErrorReportService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({ imports: [SharedTestingModule] });
     service = TestBed.inject(ErrorReportService);
   });
 

--- a/src/app/shared/modules/error/error-report.service.ts
+++ b/src/app/shared/modules/error/error-report.service.ts
@@ -1,8 +1,23 @@
 import { Injectable } from '@angular/core';
+import { PreferenceManager } from '../../services/preference-manager/preference-manager.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class ErrorReportService {
-  constructor() {}
+  private readonly preferences = this.preferenceManager.getPreferences(
+    'ErrorReportService'
+  );
+
+  readonly enabled$ = this.preferences.getBoolean$(PrefKeys.ENABLED);
+
+  constructor(private readonly preferenceManager: PreferenceManager) {}
+
+  async setEnabled(value: boolean) {
+    return this.preferences.setBoolean(PrefKeys.ENABLED, value);
+  }
+}
+
+const enum PrefKeys {
+  ENABLED = 'ENABLED',
 }

--- a/src/app/shared/modules/error/error-report.service.ts
+++ b/src/app/shared/modules/error/error-report.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ErrorReportService {
+  constructor() {}
+}

--- a/src/app/shared/modules/error/error-report.service.ts
+++ b/src/app/shared/modules/error/error-report.service.ts
@@ -1,4 +1,9 @@
 import { Injectable } from '@angular/core';
+import * as Sentry from '@sentry/angular';
+import { Integrations } from '@sentry/tracing';
+import { defer, iif } from 'rxjs';
+import { concatMap, first } from 'rxjs/operators';
+import { environment } from '../../../../environments/environment';
 import { PreferenceManager } from '../../services/preference-manager/preference-manager.service';
 
 @Injectable({
@@ -10,6 +15,38 @@ export class ErrorReportService {
   );
 
   readonly enabled$ = this.preferences.getBoolean$(PrefKeys.ENABLED);
+
+  private hasInitialized = false;
+
+  readonly initialize$ = this.enabled$.pipe(
+    concatMap(enabled =>
+      iif(
+        () => enabled && !this.hasInitialized,
+        defer(async () => {
+          Sentry.init({
+            dsn:
+              'https://6a61a79f8db44a19a96b77dcd419bda6@o584909.ingest.sentry.io/5737363',
+            integrations: [
+              new Integrations.BrowserTracing({
+                routingInstrumentation: Sentry.routingInstrumentation,
+              }),
+            ],
+
+            // Set tracesSampleRate to 1.0 to capture 100%
+            // of transactions for performance monitoring.
+            tracesSampleRate: 0.5,
+            enabled: environment.production,
+            beforeSend: async event => {
+              const enabled = await this.enabled$.pipe(first()).toPromise();
+              if (enabled) return event;
+              return null;
+            },
+          });
+          this.hasInitialized = true;
+        })
+      )
+    )
+  );
 
   constructor(private readonly preferenceManager: PreferenceManager) {}
 

--- a/src/app/shared/modules/error/error.module.ts
+++ b/src/app/shared/modules/error/error.module.ts
@@ -1,7 +1,34 @@
-import { NgModule } from '@angular/core';
+import {
+  APP_INITIALIZER,
+  ErrorHandler,
+  ModuleWithProviders,
+  NgModule,
+} from '@angular/core';
+import { Router } from '@angular/router';
+import * as Sentry from '@sentry/angular';
 
-@NgModule({
-  declarations: [],
-  imports: [],
-})
-export class ErrorModule {}
+@NgModule()
+export class ErrorModule {
+  static forRoot(): ModuleWithProviders<ErrorModule> {
+    return {
+      ngModule: ErrorModule,
+      providers: [
+        {
+          provide: ErrorHandler,
+          useValue: Sentry.createErrorHandler(),
+        },
+        {
+          provide: Sentry.TraceService,
+          deps: [Router],
+        },
+        {
+          provide: APP_INITIALIZER,
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          useFactory: () => () => {},
+          deps: [Sentry.TraceService],
+          multi: true,
+        },
+      ],
+    };
+  }
+}

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -84,6 +84,7 @@
   "forgetPassword": "Forget Password",
   "resetPassword": "Reset Password",
   "contacts": "Contacts",
+  "errorReport": "Error Report",
   ".message": "Message",
   "tutorial": {
     "switchBetween0": "Switch between",

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -84,6 +84,7 @@
   "forgetPassword": "忘記密碼",
   "resetPassword": "重設密碼",
   "contacts": "聯絡人",
+  "errorReport": "錯誤回報",
   ".message": "訊息",
   "tutorial": {
     "switchBetween0": "切換影像與收藏模式",


### PR DESCRIPTION
See #17.

Integrate Sentry error report. To comply GDPR, the error report is disabled by default. To enable the report, set on the settings page.

The report dashboard can be acessed [here](https://sentry.io/organizations/numbers-protocol/projects/capture-lite/?project=5737363).

Tested on Brave browser and Exodus 1 by throwing errors intentionally.