### PR TITLE
Support GIF as Capture asset.

### DIFF
--- a/src/app/features/home/transaction/transaction-details/transaction-details.page.html
+++ b/src/app/features/home/transaction/transaction-details/transaction-details.page.html
@@ -11,8 +11,13 @@
   <mat-card class="transaction-card">
     <mat-card-content class="row">
       <mat-label> {{ (transaction$ | ngrxPush)?.asset?.id }}</mat-label>
-      <button [class]="status$ | ngrxPush" mat-stroked-button disableRipple>
-        {{ t('transactionState.' + (status$ | ngrxPush)) }}
+      <button
+        *ngrxLet="status$ as status"
+        [class]="status"
+        mat-stroked-button
+        disableRipple
+      >
+        {{ t('transactionState.' + status) }}
       </button>
     </mat-card-content>
     <img [src]="(transaction$ | ngrxPush)?.asset?.asset_file_thumbnail" />

--- a/src/app/features/home/transaction/transaction.page.html
+++ b/src/app/features/home/transaction/transaction.page.html
@@ -20,11 +20,12 @@
         <div mat-line>{{ transaction.asset.id }}</div>
         <div mat-line>{{ transaction.created_at | date: 'short' }}</div>
         <button
-          [class]="transaction.status | ngrxPush"
+          *ngrxLet="transaction.status as status"
+          [class]="status"
           mat-stroked-button
           disableRipple
         >
-          {{ t('transactionState.' + (transaction.status | ngrxPush)) }}
+          {{ t('transactionState.' + status) }}
         </button>
       </mat-list-item>
       <mat-divider *ngIf="!isLast"></mat-divider>

--- a/src/app/utils/mime-type.ts
+++ b/src/app/utils/mime-type.ts
@@ -4,6 +4,7 @@ export type MimeType =
   | 'image/jpeg'
   | 'image/png'
   | 'image/svg+xml'
+  | 'image/gif'
   | 'video/mp4'
   | 'application/octet-stream';
 
@@ -13,6 +14,10 @@ export function toExtension(mimeType: MimeType) {
       return 'jpg';
     case 'image/png':
       return 'png';
+    case 'image/svg+xml':
+      return 'svg';
+    case 'image/gif':
+      return 'gif';
     case 'video/mp4':
       return 'mp4';
     case 'application/octet-stream':
@@ -29,6 +34,10 @@ export function fromExtension(extension: string): MimeType {
       return 'image/jpeg';
     case 'png':
       return 'image/png';
+    case 'svg':
+      return 'image/svg+xml';
+    case 'gif':
+      return 'image/gif';
     case 'mp4':
       return 'video/mp4';
     case 'bin':

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -167,7 +167,6 @@
     "returned": "Returned",
     "missed": "Returned",
     "inProgress": "In Progress",
-    "waitingToBeAccepted": "In Progress",
-    "null": "Not Provided"
+    "waitingToBeAccepted": "In Progress"
   }
 }

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -167,7 +167,6 @@
     "returned": "已退回",
     "missed": "已退回",
     "inProgress": "等待中",
-    "waitingToBeAccepted": "等待中",
-    "null": "未提供"
+    "waitingToBeAccepted": "等待中"
   }
 }


### PR DESCRIPTION
See #679.

- View GIF assets from DIA backend in app.
- View GIF PostCaptures received from friends in app.
- View GIF Captures uploaded with RESTful APIs in app.
- Delete GIF assets in app.
- Limitation: the size of GIF asset should be larger than 500 pixels to create sharable copy from DIA backend.