### PR TITLE
Feature improve home loading time

### DIFF
--- a/src/app/features/home/home.page.html
+++ b/src/app/features/home/home.page.html
@@ -78,7 +78,7 @@
       <mat-tab disabled>
         <ng-template mat-tab-label>
           <button mat-icon-button (click)="capture()">
-            <ion-icon class="tab-action-button-icon" name="camera"></ion-icon>
+            <mat-icon class="tab-action-button-icon">camera_alt</mat-icon>
           </button>
         </ng-template>
       </mat-tab>

--- a/src/app/features/home/home.page.scss
+++ b/src/app/features/home/home.page.scss
@@ -23,7 +23,6 @@ mat-sidenav-content {
   height: 24px;
   width: 24px;
   color: white;
-  margin-bottom: 2px;
 }
 
 .postcapture-tab-icon {

--- a/src/app/shared/media/media-store/media-store.service.ts
+++ b/src/app/shared/media/media-store/media-store.service.ts
@@ -154,8 +154,8 @@ export class MediaStore {
     return defer(() => this.getThumbnail(index)).pipe(
       concatMap(thumbnail => {
         if (thumbnail) {
-          return defer(() => this.read(thumbnail.thumbnailIndex)).pipe(
-            map(base64 => toDataUrl(base64, thumbnailMimeType))
+          return defer(() =>
+            this.getUrl(thumbnail.thumbnailIndex, thumbnailMimeType)
           );
         }
         if (isVideo) {

--- a/src/index.html
+++ b/src/index.html
@@ -14,7 +14,12 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="msapplication-tap-highlight" content="no" />
 
-    <link rel="icon" type="image/png" href="assets/images/launcher.svg" />
+    <link
+      rel="preload"
+      as="image"
+      type="image/png"
+      href="assets/images/launcher.svg"
+    />
 
     <!-- add to homescreen for ios -->
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/index.html
+++ b/src/index.html
@@ -28,10 +28,6 @@
       href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap"
       rel="stylesheet"
     />
-    <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
-      rel="stylesheet"
-    />
   </head>
 
   <body>


### PR DESCRIPTION
Improve the initial loading time and priority of Home page
- Use file URL instead of data URI for thumbnails to truly enable lazy loading
- Preload launcher.svg
- Remove unneeded remote Material Icon source
- Replace ion-icon which loads slowly at App startup with mat-icon