### PR TITLE
Make file input element for video hidden and removed when user cancle…

### DIFF
--- a/src/app/shared/camera/camera.service.ts
+++ b/src/app/shared/camera/camera.service.ts
@@ -54,12 +54,15 @@ export class CameraService {
   async recordVideo(): Promise<Media> {
     return new Promise<Media>((resolve, reject) => {
       const inputElement = document.createElement('input');
+      let isFileSelected = false;
       inputElement.accept = 'video/*';
       inputElement.type = 'file';
       inputElement.setAttribute('capture', 'environment');
+      inputElement.setAttribute('hidden', 'true');
       // Safari/Webkit quirk: input element must be attached to body in order to work
       document.body.appendChild(inputElement);
       inputElement.onchange = event => {
+        isFileSelected = true;
         document.body.removeChild(inputElement);
         const file = (event.target as HTMLInputElement | null)?.files?.item(0);
         if (
@@ -75,6 +78,16 @@ export class CameraService {
             })
           );
       };
+      const delayedTime = 300;
+      window.addEventListener(
+        'focus',
+        () => {
+          setTimeout(() => {
+            if (!isFileSelected) document.body.removeChild(inputElement);
+          }, delayedTime);
+        },
+        { once: true }
+      );
       inputElement.click();
     });
   }


### PR DESCRIPTION
1. When user cancel to upload video, the newly created file input element will be removed now
2. File input element is added with attribute "hidden", so that users will not see the unintended input element