### PR TITLE
Share cai-injected photo instead of sharable copy

### DIFF
--- a/src/app/shared/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/shared/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -302,6 +302,7 @@ export interface DiaBackendAsset extends Tuple {
   readonly creator_name: string;
   readonly supporting_file: string | null;
   readonly source_type: 'original' | 'post_capture' | 'store';
+  readonly cai_file: string;
 }
 
 export type AssetDownloadField =


### PR DESCRIPTION
#844 
- Share CAI-injected photo so that photos can speak for themselves
- Shared photo can be parsed by [media-reader](https://authmedia.net/media-reader) only when sharing them as "files" (e.g. sharing with gmail/gdrive, etc) 
    - iOS: Share as "saving to files" instead of "saving to photos"
    - APPs like instagram, facebook will compress the photo and the photo can not be parsed with our [media-reader](https://authmedia.net/media-reader)