### PR TITLE
Feature not cropping videos and images

### DIFF
--- a/src/app/features/home/details/details.page.scss
+++ b/src/app/features/home/details/details.page.scss
@@ -17,8 +17,7 @@
   overflow: auto;
 
   app-media {
-    min-height: 50%;
-    height: 50%;
+    width: 100%;
     object-fit: cover;
     object-position: center;
   }

--- a/src/app/features/home/sending-post-capture/sending-post-capture.page.scss
+++ b/src/app/features/home/sending-post-capture/sending-post-capture.page.scss
@@ -63,7 +63,6 @@ mat-toolbar {
   }
 
   app-media {
-    height: 50vh;
     object-fit: cover;
     object-position: center;
   }

--- a/src/app/shared/media/component/media.component.html
+++ b/src/app/shared/media/component/media.component.html
@@ -1,5 +1,7 @@
-<div *ngIf="isLoading$ | ngrxPush" class="loading-spinner-container">
-  <ion-spinner></ion-spinner>
+<div class="wrapper" *ngIf="isLoading$ | ngrxPush">
+  <div class="loading-spinner-container">
+    <ion-spinner></ion-spinner>
+  </div>
 </div>
 <ng-container *ngrxLet="src$ as src">
   <img

--- a/src/app/shared/media/component/media.component.scss
+++ b/src/app/shared/media/component/media.component.scss
@@ -8,9 +8,13 @@ img,
 video {
   display: block;
   width: 100%;
-  height: 100%;
   object-fit: inherit;
   object-position: inherit;
+}
+
+.wrapper {
+  width: 100%;
+  padding-bottom: 75%;
 }
 
 .loading-spinner-container {


### PR DESCRIPTION
#843 
- Show capture images/videos in their original aspect instead of fixed 1:1 ratio, which will usually crop them