### PR TITLE
fix: use text type to prevent incorrect code length validation

### DIFF
--- a/src/app/features/profile/phone-verification/phone-verification.page.ts
+++ b/src/app/features/profile/phone-verification/phone-verification.page.ts
@@ -100,7 +100,7 @@ export class PhoneVerificationPage {
                     type: 'input',
                     templateOptions: {
                       label: enterVerificationCodeTranslation,
-                      type: 'number',
+                      type: 'text',
                       placeholder: verificationCodePlaceHolderTranslation,
                       required: true,
                       pattern: VERIFICATION_CODE_REGEXP,


### PR DESCRIPTION
Note

The behavior of all types being used as verification code:

- `tel`: keyboard: only digits, issue: double-paste
- `number`: keyboard: digits + punctuation marks, issue: incorrect code validation
- `text`: keyboard: normal alphabet keyboard (need to switch), issue: N/A