### PR TITLE
change(dia-backend): upgrade all APIs to v3

### DIFF
--- a/src/app/shared/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/shared/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -182,7 +182,7 @@ export class DiaBackendAssetRepository {
         }
 
         return this.httpClient.get<PaginatedResponse<DiaBackendAsset>>(
-          `${BASE_URL}/api/v2/assets/`,
+          `${BASE_URL}/api/v3/assets/`,
           { headers, params }
         );
       })
@@ -193,7 +193,7 @@ export class DiaBackendAssetRepository {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers =>
         this.httpClient.get<DiaBackendAsset>(
-          `${BASE_URL}/api/v2/assets/${id}/`,
+          `${BASE_URL}/api/v3/assets/${id}/`,
           { headers }
         )
       )
@@ -206,7 +206,7 @@ export class DiaBackendAssetRepository {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers =>
         this.httpClient.post(
-          `${BASE_URL}/api/v2/assets/${id}/download/`,
+          `${BASE_URL}/api/v3/assets/${id}/download/`,
           formData,
           { headers, responseType: 'blob' }
         )
@@ -236,7 +236,7 @@ export class DiaBackendAssetRepository {
     ]).pipe(
       concatMap(([headers, formData]) =>
         this.httpClient.patch<UpdateAssetResponse>(
-          `${BASE_URL}/api/v2/assets/${proof.diaBackendAssetId}/`,
+          `${BASE_URL}/api/v3/assets/${proof.diaBackendAssetId}/`,
           formData,
           { headers }
         )
@@ -251,7 +251,7 @@ export class DiaBackendAssetRepository {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers =>
         this.httpClient.delete<DeleteAssetResponse>(
-          `${BASE_URL}/api/v2/assets/${id}/`,
+          `${BASE_URL}/api/v3/assets/${id}/`,
           { headers }
         )
       ),
@@ -273,7 +273,7 @@ export class DiaBackendAssetRepository {
     return defer(() => this.authService.getAuthHeadersWithApiKey()).pipe(
       concatMap(headers => {
         return this.httpClient.post(
-          `${BASE_URL}/api/v2/assets/${id}/mint/`,
+          `${BASE_URL}/api/v3/assets/${id}/mint/`,
           formData,
           { headers }
         );

--- a/src/app/shared/dia-backend/asset/uploading/dia-backend-asset-uploading.service.ts
+++ b/src/app/shared/dia-backend/asset/uploading/dia-backend-asset-uploading.service.ts
@@ -130,8 +130,7 @@ export class DiaBackendAssetUploadingService {
         return throwError(err);
       }),
       map(diaBackendAsset => {
-        // NOTE: need to change to diaBackendAsset.id when migrate to v3
-        proof.diaBackendAssetId = diaBackendAsset.uuid;
+        proof.diaBackendAssetId = diaBackendAsset.id;
         return proof;
       }),
       retryWhen(err$ =>

--- a/src/app/shared/dia-backend/contact/dia-backend-contact-repository.service.ts
+++ b/src/app/shared/dia-backend/contact/dia-backend-contact-repository.service.ts
@@ -61,7 +61,7 @@ export class DiaBackendContactRepository {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers =>
         this.httpClient.post<ContactDeleteResponse>(
-          `${BASE_URL}/api/v2/contacts/delete/`,
+          `${BASE_URL}/api/v3/contacts/delete/`,
           { email },
           { headers }
         )
@@ -95,7 +95,7 @@ export class DiaBackendContactRepository {
         }
 
         return this.httpClient.get<PaginatedResponse<DiaBackendContact>>(
-          `${BASE_URL}/api/v2/contacts/`,
+          `${BASE_URL}/api/v3/contacts/`,
           { headers, params }
         );
       }),

--- a/src/app/shared/dia-backend/series/dia-backend-series-repository.service.ts
+++ b/src/app/shared/dia-backend/series/dia-backend-series-repository.service.ts
@@ -46,7 +46,7 @@ export class DiaBackendSeriesRepository {
           params = params.set('collected', `${collected}`);
         }
         return this.httpClient.get<PaginatedResponse<DiaBackendSeries>>(
-          `${BASE_URL}/api/v2/series/`,
+          `${BASE_URL}/api/v3/series/`,
           { headers, params }
         );
       })
@@ -57,7 +57,7 @@ export class DiaBackendSeriesRepository {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers =>
         this.httpClient.get<DiaBackendSeries>(
-          `${BASE_URL}/api/v2/series/${id}/`,
+          `${BASE_URL}/api/v3/series/${id}/`,
           { headers }
         )
       )

--- a/src/app/shared/dia-backend/transaction/dia-backend-transaction-repository.service.ts
+++ b/src/app/shared/dia-backend/transaction/dia-backend-transaction-repository.service.ts
@@ -116,7 +116,7 @@ export class DiaBackendTransactionRepository {
           params = params.set('limit', `${limit}`);
         }
         return this.httpClient.get<PaginatedResponse<DiaBackendTransaction>>(
-          `${BASE_URL}/api/v2/transactions/inbox/`,
+          `${BASE_URL}/api/v3/transactions/inbox/`,
           { headers, params }
         );
       })
@@ -138,7 +138,7 @@ export class DiaBackendTransactionRepository {
         }
 
         return this.httpClient.get<PaginatedResponse<DiaBackendTransaction>>(
-          `${BASE_URL}/api/v2/transactions/`,
+          `${BASE_URL}/api/v3/transactions/`,
           { headers, params }
         );
       }),
@@ -150,7 +150,7 @@ export class DiaBackendTransactionRepository {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers =>
         this.httpClient.get<DiaBackendTransaction>(
-          `${BASE_URL}/api/v2/transactions/${id}/`,
+          `${BASE_URL}/api/v3/transactions/${id}/`,
           { headers }
         )
       )
@@ -171,7 +171,7 @@ export class DiaBackendTransactionRepository {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers =>
         this.httpClient.post<CreateTransactionResponse>(
-          `${BASE_URL}/api/v2/transactions/`,
+          `${BASE_URL}/api/v3/transactions/`,
           {
             asset_id: assetId,
             email: targetEmail,
@@ -197,7 +197,7 @@ export class DiaBackendTransactionRepository {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers =>
         this.httpClient.post<AcceptTransactionResponse>(
-          `${BASE_URL}/api/v2/transactions/${id}/accept/`,
+          `${BASE_URL}/api/v3/transactions/${id}/accept/`,
           {},
           { headers }
         )
@@ -214,7 +214,7 @@ export class DiaBackendTransactionRepository {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers =>
         this.httpClient.post<AcceptTransactionResponse>(
-          `${BASE_URL}/api/v2/transactions/${id}/ignore/`,
+          `${BASE_URL}/api/v3/transactions/${id}/ignore/`,
           {},
           { headers }
         )

--- a/src/app/shared/dia-backend/wallet/dia-backend-wallet.service.ts
+++ b/src/app/shared/dia-backend/wallet/dia-backend-wallet.service.ts
@@ -30,7 +30,7 @@ export class DiaBackendWalletService {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers => {
         return this.httpClient.get<DiaBackendWallet>(
-          `${BASE_URL}/api/v2/wallets/asset-wallet/`,
+          `${BASE_URL}/api/v3/wallets/asset-wallet/`,
           { headers }
         );
       })
@@ -43,7 +43,7 @@ export class DiaBackendWalletService {
         const formData = new FormData();
         formData.set('private_key', privateKey);
         return this.httpClient.post<DiaBackendWallet>(
-          `${BASE_URL}/api/v2/wallets/asset-wallet/`,
+          `${BASE_URL}/api/v3/wallets/asset-wallet/`,
           formData,
           { headers }
         );
@@ -55,7 +55,7 @@ export class DiaBackendWalletService {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers => {
         return this.httpClient.get<DiaBackendWallet>(
-          `${BASE_URL}/api/v2/wallets/managed-wallet/`,
+          `${BASE_URL}/api/v3/wallets/managed-wallet/`,
           { headers }
         );
       })


### PR DESCRIPTION
#972 

* Upgrade all dia-backend API to v3
* For `proof`, users need to refresh captures (drag-down) to normally transfer, delete, or mint NFT for capture. (since the `diaBackendAssetId` stored locally is `uuid` originally, and after refresh, it should be replaced by `id`, which is `cid` in v3)
  * `post-capture` and `series` are not affected



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1201263659416800) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
