### PR TITLE
add(actions-dialog): add action parameter selection dialog

### DIFF
--- a/src/app/shared/actions/actions-dialog/actions-dialog.component.html
+++ b/src/app/shared/actions/actions-dialog/actions-dialog.component.html
@@ -1,0 +1,20 @@
+<div *transloco="let t">
+  <h2 mat-dialog-title>{{ title }}</h2>
+  <p>{{ description }}</p>
+
+  <form [formGroup]="form" (ngSubmit)="send()">
+    <formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="cancel()">{{ t('cancel') }}</button>
+      <button
+        mat-button
+        type="submit"
+        [disabled]="!form.valid"
+        color="primary"
+        cdkFocusInitial
+      >
+        {{ t('ok') }}
+      </button>
+    </mat-dialog-actions>
+  </form>
+</div>

--- a/src/app/shared/actions/actions-dialog/actions-dialog.component.html
+++ b/src/app/shared/actions/actions-dialog/actions-dialog.component.html
@@ -2,19 +2,19 @@
   <h2 mat-dialog-title>{{ title }}</h2>
   <p>{{ description }}</p>
 
-  <form [formGroup]="form" (ngSubmit)="send()">
+  <form [formGroup]="form">
     <formly-form [form]="form" [fields]="fields" [model]="model"></formly-form>
-    <mat-dialog-actions align="end">
-      <button mat-button (click)="cancel()">{{ t('cancel') }}</button>
-      <button
-        mat-button
-        type="submit"
-        [disabled]="!form.valid"
-        color="primary"
-        cdkFocusInitial
-      >
-        {{ t('ok') }}
-      </button>
-    </mat-dialog-actions>
   </form>
+  <mat-dialog-actions align="end">
+    <button mat-button (click)="cancel()">{{ t('cancel') }}</button>
+    <button
+      mat-button
+      [disabled]="!form.valid"
+      color="primary"
+      cdkFocusInitial
+      (click)="send()"
+    >
+      {{ t('ok') }}
+    </button>
+  </mat-dialog-actions>
 </div>

--- a/src/app/shared/actions/actions-dialog/actions-dialog.component.spec.ts
+++ b/src/app/shared/actions/actions-dialog/actions-dialog.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { SharedTestingModule } from '../../shared-testing.module';
+import { ActionsDialogComponent } from './actions-dialog.component';
+
+describe('ActionsDialogComponent', () => {
+  let component: ActionsDialogComponent;
+  let fixture: ComponentFixture<ActionsDialogComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ActionsDialogComponent],
+        imports: [SharedTestingModule],
+        providers: [
+          { provide: MatDialogRef, useValue: {} },
+          { provide: MAT_DIALOG_DATA, useValue: {} },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(ActionsDialogComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    })
+  );
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/actions/actions-dialog/actions-dialog.component.ts
+++ b/src/app/shared/actions/actions-dialog/actions-dialog.component.ts
@@ -52,12 +52,26 @@ export class ActionsDialogComponent {
             required: true,
           },
         });
+      else if (param.type_text === 'number')
+        this.fields.push({
+          key: param.name_text,
+          type: 'input',
+          templateOptions: {
+            type: 'number',
+            label: param.display_text_text,
+            placeholder: param.placeholder_text,
+            disabled: !param.user_input_boolean,
+            max: param.max_number,
+            min: param.min_number,
+            required: true,
+          },
+        });
       else
         this.fields.push({
           key: param.name_text,
           type: 'input',
           templateOptions: {
-            type: param.type_text,
+            type: 'text',
             label: param.display_text_text,
             placeholder: param.placeholder_text,
             disabled: !param.user_input_boolean,

--- a/src/app/shared/actions/actions-dialog/actions-dialog.component.ts
+++ b/src/app/shared/actions/actions-dialog/actions-dialog.component.ts
@@ -1,0 +1,82 @@
+import { Component, Inject } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { FormlyFieldConfig } from '@ngx-formly/core';
+import { Action, Param } from '../service/actions.service';
+
+@Component({
+  selector: 'app-actions-dialog',
+  templateUrl: './actions-dialog.component.html',
+  styleUrls: ['./actions-dialog.component.scss'],
+})
+export class ActionsDialogComponent {
+  readonly form = new FormGroup({});
+  readonly fields: FormlyFieldConfig[] = [];
+  readonly model: any = {};
+
+  readonly title: string = '';
+  readonly description: string = '';
+  readonly params: Param[] = [];
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<ActionsDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: MatDialogData
+  ) {
+    if (data.action !== undefined && data.params !== undefined) {
+      this.title = data.action.title_text;
+      this.description = data.action.description_text;
+      this.params = data.params;
+      this.createFormModel();
+      this.createFormFields();
+    }
+  }
+
+  private createFormModel() {
+    for (const param of this.params)
+      this.model[param.name_text] = param.default_values_list_text[0] || '';
+  }
+
+  private createFormFields() {
+    for (const param of this.params) {
+      if (param.type_text === 'dropdown')
+        this.fields.push({
+          key: param.name_text,
+          type: 'select',
+          templateOptions: {
+            options: param.default_values_list_text.map(value => ({
+              label: value,
+              value: value,
+            })),
+            placeholder: param.placeholder_text,
+            disabled: !param.user_input_boolean,
+            required: true,
+          },
+        });
+      else
+        this.fields.push({
+          key: param.name_text,
+          type: 'input',
+          templateOptions: {
+            type: param.type_text,
+            label: param.display_text_text,
+            placeholder: param.placeholder_text,
+            disabled: !param.user_input_boolean,
+            required: true,
+          },
+        });
+    }
+  }
+
+  send() {
+    this.dialogRef.close(this.model);
+  }
+
+  cancel() {
+    this.dialogRef.close();
+  }
+}
+
+interface MatDialogData {
+  action: Action | undefined;
+  params: Param[] | undefined;
+}

--- a/src/app/shared/actions/service/actions.service.spec.ts
+++ b/src/app/shared/actions/service/actions.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { SharedTestingModule } from '../shared-testing.module';
+import { SharedTestingModule } from '../../shared-testing.module';
 import { ActionsService } from './actions.service';
 
 describe('ActionsService', () => {

--- a/src/app/shared/actions/service/actions.service.ts
+++ b/src/app/shared/actions/service/actions.service.ts
@@ -52,6 +52,8 @@ export interface Param {
   readonly placeholder_text: string;
   readonly type_text: 'number' | 'text' | 'dropdown';
   readonly user_input_boolean: boolean;
+  readonly max_number: number;
+  readonly min_number: number;
 }
 
 export interface GetActionsResponse<T> {

--- a/src/app/shared/actions/service/actions.service.ts
+++ b/src/app/shared/actions/service/actions.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { defer, forkJoin } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { BUBBLE_DB_URL } from '../dia-backend/secret';
+import { BUBBLE_DB_URL } from '../../dia-backend/secret';
 
 @Injectable({
   providedIn: 'root',
@@ -50,7 +50,7 @@ export interface Param {
   readonly display_text_text: string;
   readonly name_text: string;
   readonly placeholder_text: string;
-  readonly type_text: string;
+  readonly type_text: 'number' | 'text' | 'dropdown';
   readonly user_input_boolean: boolean;
 }
 

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -2,9 +2,13 @@ import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatDialogModule } from '@angular/material/dialog';
 import { IonicModule } from '@ionic/angular';
 import { TranslocoModule } from '@ngneat/transloco';
 import { ReactiveComponentModule } from '@ngrx/component';
+import { FormlyModule } from '@ngx-formly/core';
+import { FormlyMaterialModule } from '@ngx-formly/material';
+import { ActionsDialogComponent } from './actions/actions-dialog/actions-dialog.component';
 import { AvatarComponent } from './avatar/avatar.component';
 import { CapacitorPluginsModule } from './capacitor-plugins/capacitor-plugins.module';
 import { ContactSelectionDialogComponent } from './contact-selection-dialog/contact-selection-dialog.component';
@@ -16,6 +20,7 @@ import { StartsWithPipe } from './pipes/starts-with/starts-with.pipe';
 
 const declarations = [
   MigratingDialogComponent,
+  ActionsDialogComponent,
   AvatarComponent,
   MediaComponent,
   StartsWithPipe,
@@ -33,6 +38,9 @@ const imports = [
   MaterialModule,
   CapacitorPluginsModule,
   ReactiveComponentModule,
+  MatDialogModule,
+  FormlyModule,
+  FormlyMaterialModule,
 ];
 
 @NgModule({


### PR DESCRIPTION
#1049 

* Use `mat-dialog` instead of `ionic alert` to support multiple types of input
  * text input
  * number input
  * dropdown (select)
* Display more information about each input
* Checking the input when submitting the form



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1201515367303313) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
