### PR TITLE
fix(ios/App/App/Info.plist): make the default language of camera to b…

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>zh_TW</string>
+	<string>en_US</string>
 	<key>CFBundleDisplayName</key>
 	<string>Capture</string>
 	<key>CFBundleExecutable</key>
@@ -14,8 +14,8 @@
 	<string>6.0</string>
 	<key>CFBundleLocalizations</key>
 	<array>
-		<string>zh_TW</string>
 		<string>en</string>
+		<string>zh_TW</string>
 	</array>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>


### PR DESCRIPTION
There are two cases:
- If either `zh_TW` or `en_US` appear in the system's preferred language order list, the language of the APP will be the one with higher order.
- Otherwise, the language will be `en_US` (will be `zh_TW` before this commit).