### PR TITLE
feat(profile.page): do not show user's private key directly

### DIFF
--- a/src/app/features/profile/profile.page.html
+++ b/src/app/features/profile/profile.page.html
@@ -118,19 +118,15 @@
         <mat-icon>content_copy</mat-icon>
       </button>
     </mat-list-item>
-    <mat-list-item>
-      <mat-icon mat-list-icon>vpn_key</mat-icon>
-      <div mat-line>{{ t('privateKey') }}</div>
-      <div mat-line>{{ privateKey$ | ngrxPush }}</div>
-      <button
-        *ngIf="privateKey$ | ngrxPush as privateKey"
-        (click)="copyPrivateKey(privateKey)"
-        mat-icon-button
-      >
-        <mat-icon>content_copy</mat-icon>
-      </button>
-    </mat-list-item>
   </mat-list>
+  <button
+    (click)="exportPrivateKey()"
+    class="expand"
+    color="primary"
+    mat-stroked-button
+  >
+    {{ t('exportPrivateKey') }}
+  </button>
   <button (click)="logout()" class="expand" color="primary" mat-stroked-button>
     {{ t('logout') }}
   </button>

--- a/src/app/shared/export-private-key-modal/export-private-key-modal.component.html
+++ b/src/app/shared/export-private-key-modal/export-private-key-modal.component.html
@@ -1,0 +1,13 @@
+<div *transloco="let t">
+  <h2 mat-dialog-title>
+    {{ t('yourPrivateKey') }}
+  </h2>
+  <p>{{ privateKey }}</p>
+  <button
+    (click)="copyToClipboard(privateKey)"
+    color="primary"
+    mat-stroked-button
+  >
+    <mat-icon>content_copy</mat-icon> {{ t('copyToClipboard') }}
+  </button>
+</div>

--- a/src/app/shared/export-private-key-modal/export-private-key-modal.component.scss
+++ b/src/app/shared/export-private-key-modal/export-private-key-modal.component.scss
@@ -1,0 +1,3 @@
+button {
+  width: 100%;
+}

--- a/src/app/shared/export-private-key-modal/export-private-key-modal.component.spec.ts
+++ b/src/app/shared/export-private-key-modal/export-private-key-modal.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { SharedTestingModule } from '../../shared/shared-testing.module';
+import { ExportPrivateKeyModalComponent } from './export-private-key-modal.component';
+
+describe('ActionsDialogComponent', () => {
+  let component: ExportPrivateKeyModalComponent;
+  let fixture: ComponentFixture<ExportPrivateKeyModalComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [ExportPrivateKeyModalComponent],
+        imports: [SharedTestingModule],
+        providers: [
+          { provide: MatDialogRef, useValue: {} },
+          { provide: MAT_DIALOG_DATA, useValue: {} },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(ExportPrivateKeyModalComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    })
+  );
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/export-private-key-modal/export-private-key-modal.component.ts
+++ b/src/app/shared/export-private-key-modal/export-private-key-modal.component.ts
@@ -1,0 +1,37 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Plugins } from '@capacitor/core';
+import { TranslocoService } from '@ngneat/transloco';
+
+const { Clipboard } = Plugins;
+
+@Component({
+  selector: 'app-export-private-key-modal',
+  templateUrl: './export-private-key-modal.component.html',
+  styleUrls: ['./export-private-key-modal.component.scss'],
+})
+export class ExportPrivateKeyModalComponent {
+  readonly privateKey: string = '';
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<ExportPrivateKeyModalComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: MatDialogData,
+    private readonly translocoService: TranslocoService,
+    private readonly snackBar: MatSnackBar
+  ) {
+    this.privateKey = data.privateKey;
+  }
+
+  async copyToClipboard(privateKey: string) {
+    await Clipboard.write({ string: privateKey });
+    this.snackBar.open(
+      this.translocoService.translate('message.copiedToClipboard')
+    );
+    this.dialogRef.close();
+  }
+}
+
+interface MatDialogData {
+  privateKey: string;
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -13,6 +13,7 @@ import { AvatarComponent } from './avatar/avatar.component';
 import { CapacitorPluginsModule } from './capacitor-plugins/capacitor-plugins.module';
 import { ContactSelectionDialogComponent } from './contact-selection-dialog/contact-selection-dialog.component';
 import { FriendInvitationDialogComponent } from './contact-selection-dialog/friend-invitation-dialog/friend-invitation-dialog.component';
+import { ExportPrivateKeyModalComponent } from './export-private-key-modal/export-private-key-modal.component';
 import { MaterialModule } from './material/material.module';
 import { MediaComponent } from './media/component/media.component';
 import { MigratingDialogComponent } from './migration/migrating-dialog/migrating-dialog.component';
@@ -26,6 +27,7 @@ const declarations = [
   StartsWithPipe,
   ContactSelectionDialogComponent,
   FriendInvitationDialogComponent,
+  ExportPrivateKeyModalComponent,
 ];
 
 const imports = [

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -95,6 +95,9 @@
   "resendIn": "Re-send {{ secondsRemained }}s",
   "balance": "Balance",
   "walletAddress": "Wallet Address",
+  "exportPrivateKey": "Export Private Key",
+  "yourPrivateKey": "Your Private Key",
+  "copyToClipboard": "Copy To Clipboard",
   "verification": {
     "verification": "Verification",
     "clickToVerify": "Click me to verify",

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -95,6 +95,9 @@
   "resendIn": "重新發送 {{ secondsRemained }}秒",
   "balance": "餘額",
   "walletAddress": "錢包地址",
+  "exportPrivateKey": "匯出私鑰",
+  "yourPrivateKey": "您的私鑰",
+  "copyToClipboard": "複製到剪貼簿",
   "verification": {
     "verification": "驗證",
     "clickToVerify": "點擊驗證",


### PR DESCRIPTION
- User can see their private key after confirming with the warnings

Current UX flow:
1. Click "Export Private Key" button
2. Show the warnings. If proceed, go to step 3. Otherwise, the flow is ended
3. Show the private key, and user can copy to clipboard