### PR TITLE
Feature support num payment

### DIFF
--- a/src/app/features/home/details/actions/actions.page.html
+++ b/src/app/features/home/details/actions/actions.page.html
@@ -7,7 +7,7 @@
 
 <div class="page-content">
   <ng-container *ngFor="let action of actions$ | ngrxPush">
-    <ion-card (click)="openAction(action)">
+    <ion-card (click)="doAction(action)">
       <ion-card-header>
         <div class="wrapper">
           <div>

--- a/src/app/features/home/details/actions/actions.page.ts
+++ b/src/app/features/home/details/actions/actions.page.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -106,6 +107,13 @@ export class ActionsPage {
   confirmOrder$(id: string) {
     return this.storeService.confirmNetworkAppOrder(id).pipe(
       catchError((err: unknown) => {
+        if (err instanceof HttpErrorResponse) {
+          const errorType = err.error.error?.type;
+          if (errorType === 'insufficient_fund')
+            return this.errorService.toastError$(
+              this.translocoService.translate(`error.diaBackend.${errorType}`)
+            );
+        }
         return this.errorService.toastError$(err);
       }),
       isNonNullable()

--- a/src/app/shared/actions/service/actions.service.ts
+++ b/src/app/shared/actions/service/actions.service.ts
@@ -42,6 +42,7 @@ export interface Action {
   readonly description_text: string;
   readonly params_list_custom_param1: string[];
   readonly title_text: string;
+  readonly network_app_id_text: string;
 }
 
 export interface Param {

--- a/src/app/shared/dia-backend/store/dia-backend-store.service.spec.ts
+++ b/src/app/shared/dia-backend/store/dia-backend-store.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { SharedTestingModule } from '../../shared-testing.module';
+import { DiaBackendStoreService } from './dia-backend-store.service';
+
+describe('DiaBackendStoreService', () => {
+  let service: DiaBackendStoreService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [SharedTestingModule],
+    });
+    service = TestBed.inject(DiaBackendStoreService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/dia-backend/store/dia-backend-store.service.ts
+++ b/src/app/shared/dia-backend/store/dia-backend-store.service.ts
@@ -1,0 +1,63 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { defer } from 'rxjs';
+import { concatMap } from 'rxjs/operators';
+import { DiaBackendAuthService } from '../auth/dia-backend-auth.service';
+import { BASE_URL } from '../secret';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DiaBackendStoreService {
+  constructor(
+    private readonly httpClient: HttpClient,
+    private readonly authService: DiaBackendAuthService
+  ) {}
+
+  createNetworkAppOrder(networkApp: string, actionArgs: any) {
+    return defer(() => this.authService.getAuthHeadersWithApiKey()).pipe(
+      concatMap(headers => {
+        return this.httpClient.post<NetworkAppOrderStatus>(
+          `${BASE_URL}/api/v3/store/network-app-orders/`,
+          {
+            network_app: networkApp,
+            action_args: actionArgs,
+          },
+          { headers }
+        );
+      })
+    );
+  }
+
+  confirmNetworkAppOrder(id: string) {
+    return defer(() => this.authService.getAuthHeadersWithApiKey()).pipe(
+      concatMap(headers => {
+        return this.httpClient.post<NetworkAppOrderStatus>(
+          `${BASE_URL}/api/v3/store/network-app-orders/${id}/confirm/`,
+          {},
+          { headers }
+        );
+      })
+    );
+  }
+}
+
+export interface NetworkAppOrderStatus {
+  id: string;
+  status: 'completed' | 'canceled' | 'pending';
+  network_app: string;
+  action: string;
+  action_args: Record<string, unknown>;
+  price: string;
+  fee: string | null;
+  total_cost: string;
+  quantity: number;
+  fund_crypto_transaction_id: string;
+  fund_tx_hash: string;
+  payment_crypto_transaction_id: string;
+  payment_tx_hash: string;
+  workflow_id: string;
+  owner: string;
+  created_at: string;
+  expired_at: string;
+}

--- a/src/app/shared/order-detail-dialog/order-detail-dialog.component.html
+++ b/src/app/shared/order-detail-dialog/order-detail-dialog.component.html
@@ -1,0 +1,33 @@
+<div *transloco="let t">
+  <h2 mat-dialog-title>{{ t('payment.confirmPayment') }}</h2>
+  <ion-row style="border-bottom: groove">
+    <ion-col>
+      <ion-label>{{ t('payment.price') }}</ion-label>
+    </ion-col>
+    <ion-col align="end">
+      <ion-label>{{ orderStatus.price | number: '1.2-2' }} NUM</ion-label>
+    </ion-col>
+  </ion-row>
+  <ion-row style="border-bottom: groove">
+    <ion-col>
+      <ion-label>{{ t('payment.fee') }}</ion-label>
+    </ion-col>
+    <ion-col align="end">
+      <ion-label>{{ orderStatus.fee | number: '1.2-2' }} NUM</ion-label>
+    </ion-col>
+  </ion-row>
+  <ion-row>
+    <ion-col>
+      <ion-label>{{ t('payment.totalCost') }}</ion-label>
+    </ion-col>
+    <ion-col align="end">
+      <ion-label>{{ orderStatus.total_cost | number: '1.2-2' }} NUM</ion-label>
+    </ion-col>
+  </ion-row>
+  <mat-dialog-actions align="end">
+    <button mat-button (click)="cancel()">{{ t('cancel') }}</button>
+    <button mat-button color="primary" (click)="ok()">
+      {{ t('ok') }}
+    </button>
+  </mat-dialog-actions>
+</div>

--- a/src/app/shared/order-detail-dialog/order-detail-dialog.component.spec.ts
+++ b/src/app/shared/order-detail-dialog/order-detail-dialog.component.spec.ts
@@ -1,0 +1,30 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { SharedTestingModule } from '../../shared/shared-testing.module';
+import { OrderDetailDialogComponent } from './order-detail-dialog.component';
+
+describe('ActionsDialogComponent', () => {
+  let component: OrderDetailDialogComponent;
+  let fixture: ComponentFixture<OrderDetailDialogComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [OrderDetailDialogComponent],
+        imports: [SharedTestingModule],
+        providers: [
+          { provide: MatDialogRef, useValue: {} },
+          { provide: MAT_DIALOG_DATA, useValue: {} },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(OrderDetailDialogComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    })
+  );
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/order-detail-dialog/order-detail-dialog.component.ts
+++ b/src/app/shared/order-detail-dialog/order-detail-dialog.component.ts
@@ -1,0 +1,27 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { NetworkAppOrderStatus } from '../dia-backend/store/dia-backend-store.service';
+
+@Component({
+  selector: 'app-order-detail-dialog',
+  templateUrl: './order-detail-dialog.component.html',
+  styleUrls: ['./order-detail-dialog.component.scss'],
+})
+export class OrderDetailDialogComponent {
+  readonly orderStatus: NetworkAppOrderStatus;
+
+  constructor(
+    private readonly dialogRef: MatDialogRef<OrderDetailDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: NetworkAppOrderStatus
+  ) {
+    this.orderStatus = data;
+  }
+
+  ok() {
+    this.dialogRef.close(this.orderStatus.id);
+  }
+
+  cancel() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -17,6 +17,7 @@ import { ExportPrivateKeyModalComponent } from './export-private-key-modal/expor
 import { MaterialModule } from './material/material.module';
 import { MediaComponent } from './media/component/media.component';
 import { MigratingDialogComponent } from './migration/migrating-dialog/migrating-dialog.component';
+import { OrderDetailDialogComponent } from './order-detail-dialog/order-detail-dialog.component';
 import { StartsWithPipe } from './pipes/starts-with/starts-with.pipe';
 
 const declarations = [
@@ -28,6 +29,7 @@ const declarations = [
   ContactSelectionDialogComponent,
   FriendInvitationDialogComponent,
   ExportPrivateKeyModalComponent,
+  OrderDetailDialogComponent,
 ];
 
 const imports = [

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -201,7 +201,8 @@
       "throttled": "Too frequent request",
       "user_is_email_verified": "The email address has beed verified",
       "user_not_found": "There is no account registered with the email address",
-      "asset_is_being_minted": "Asset is being minted"
+      "asset_is_being_minted": "Asset is being minted",
+      "insufficient_fund": "Insufficient Fund"
     }
   },
   "transactionState": {

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -211,5 +211,11 @@
     "missed": "Returned",
     "inProgress": "In Progress",
     "waitingToBeAccepted": "In Progress"
+  },
+  "payment": {
+    "confirmPayment": "Confirm Payment",
+    "price": "Price",
+    "fee": "Fee",
+    "totalCost": "Total Cost"
   }
 }

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -202,7 +202,7 @@
       "user_is_email_verified": "The email address has beed verified",
       "user_not_found": "There is no account registered with the email address",
       "asset_is_being_minted": "Asset is being minted",
-      "insufficient_fund": "Insufficient Fund"
+      "insufficient_fund": "Insufficient NUM token"
     }
   },
   "transactionState": {

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -202,7 +202,7 @@
       "user_is_email_verified": "此電子郵件已驗證",
       "user_not_found": "此電子郵件尚未註冊 Capture 帳號",
       "asset_is_being_minted": "NFT 代幣鑄造中",
-      "insufficient_fund": "餘額不足"
+      "insufficient_fund": "NUM 餘額不足"
     }
   },
   "transactionState": {

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -201,7 +201,8 @@
       "throttled": "短時間內傳送過多請求",
       "user_is_email_verified": "此電子郵件已驗證",
       "user_not_found": "此電子郵件尚未註冊 Capture 帳號",
-      "asset_is_being_minted": "NFT 代幣鑄造中"
+      "asset_is_being_minted": "NFT 代幣鑄造中",
+      "insufficient_fund": "餘額不足"
     }
   },
   "transactionState": {

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -211,5 +211,11 @@
     "missed": "已退回",
     "inProgress": "等待中",
     "waitingToBeAccepted": "等待中"
+  },
+  "payment": {
+    "confirmPayment": "確認付款",
+    "price": "價格",
+    "fee": "手續費",
+    "totalCost": "總額"
   }
 }


### PR DESCRIPTION
Support  NUM payment for Network APPs

* Add `dia-backend-store.service`: create network app order, confirm network app order.
* Add `order-detail-dialog.component`: display order detail before confirming the order.
* Modify the flow when submitting Network APP request.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1201651086081455) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
