### PR TITLE
fix(dia-backend-asset-refreshing.service.ts): ignore refresh if there…

### DIFF
--- a/src/app/shared/dia-backend/asset/refreshing/dia-backend-asset-refreshing.service.ts
+++ b/src/app/shared/dia-backend/asset/refreshing/dia-backend-asset-refreshing.service.ts
@@ -1,23 +1,37 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { EMPTY, forkJoin } from 'rxjs';
 import { catchError, concatMap, first } from 'rxjs/operators';
 import { HttpErrorCode } from '../../../error/error.service';
 import { ProofRepository } from '../../../repositories/proof/proof-repository.service';
 import { DiaBackendAssetRepository } from '../dia-backend-asset-repository.service';
 import { DiaBackendAssetPrefetchingService } from '../prefetching/dia-backend-asset-prefetching.service';
+import { DiaBackendAssetUploadingService } from '../uploading/dia-backend-asset-uploading.service';
 
+@UntilDestroy()
 @Injectable({
   providedIn: 'root',
 })
 export class DiaBackendAsseRefreshingService {
+  private pendingUploadTasks = 0;
+
   constructor(
     private readonly assetRepository: DiaBackendAssetRepository,
     private readonly proofRepository: ProofRepository,
-    private readonly diaBackendAssetPrefetchingService: DiaBackendAssetPrefetchingService
-  ) {}
+    private readonly diaBackendAssetPrefetchingService: DiaBackendAssetPrefetchingService,
+    private readonly uploadService: DiaBackendAssetUploadingService
+  ) {
+    this.uploadService.pendingTasks$
+      .pipe(untilDestroyed(this))
+      .subscribe(value => (this.pendingUploadTasks = value));
+  }
 
   refresh() {
+    // Don't refresh if there are still captures being uploaded.
+    if (this.pendingUploadTasks > 0) {
+      return EMPTY;
+    }
     return this.proofRepository.all$.pipe(
       first(),
       concatMap(proofs =>


### PR DESCRIPTION
Fix [拍攝 capture 後未上傳完成 , 使用 "重整功能" 圖會直接被刪除 #918](https://github.com/numbersprotocol/capture-lite/issues/918). I implemented what James suggested [here](https://github.com/numbersprotocol/capture-lite/issues/918#issuecomment-1032217059).

## Test Plan
I tested it on my iPhone: https://youtu.be/Ym5CJa5wC8I
```bash
➜  capture-lite git:(feature-fix-capture-disappear-after-refresh) ✗ npm run lint

> capture-lite@0.47.0 lint
> npm run preconfig && prettier --check . && stylelint "**/*.{css,scss,sass}" && ng lint


> capture-lite@0.47.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

Checking formatting...
All matched files use Prettier code style!
Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating

Linting "app"...

/Users/rayhung/Desktop/Numbers Protocol/capture-lite/src/app/features/settings/go-pro/services/go-pro-bluetooth.service.ts
  163:7  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  187:9  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  195:9  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

/Users/rayhung/Desktop/Numbers Protocol/capture-lite/src/app/features/settings/go-pro/services/go-pro-media.service.ts
   60:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
   64:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
   71:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
   75:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  125:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  291:7   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  296:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  303:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  311:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  312:21  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

/Users/rayhung/Desktop/Numbers Protocol/capture-lite/src/app/features/settings/go-pro/services/go-pro-wifi.service.ts
  40:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

✖ 14 problems (0 errors, 14 warnings)

Lint warnings found in the listed files.

➜  capture-lite git:(feature-fix-capture-disappear-after-refresh) ✗ 
```

```bash
➜  capture-lite git:(feature-fix-capture-disappear-after-refresh) ✗ npm run test.ci 

> capture-lite@0.47.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.47.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

09 02 2022 12:36:48.017:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
09 02 2022 12:36:48.018:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
09 02 2022 12:36:48.020:INFO [launcher]: Starting browser ChromeHeadless
09 02 2022 12:36:54.663:INFO [Chrome Headless 98.0.4758.80 (Mac OS 10.15.7)]: Connected on socket hZZRPeiIpjJ0e70sAAAB with id 25731703
Chrome Headless 98.0.4758.80 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.80 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:154115:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.80 (Mac OS 10.15.7): Executed 213 of 213 (2 FAILED) (26.026 secs / 25.834 secs)
TOTAL: 2 FAILED, 211 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.99% ( 1722/3377 )
Branches     : 29.65% ( 287/968 )
Functions    : 40.52% ( 611/1508 )
Lines        : 52.98% ( 1555/2935 )
================================================================================
➜  capture-lite git:(feature-fix-capture-disappear-after-refresh) ✗
```