### PR TITLE
build: bump version to 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix [拍攝 capture 後未上傳完成 , 使用 "重整功能" 圖會直接被刪除](https://github.com/numbersprotocol/capture-lite/issues/918)
+- Unuploaded Captures disappear after user pulls to refresh. #918
 
 ## 0.47.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.48.0 - 2022-02-10
+
+### Fixed
+
+- Fix [拍攝 capture 後未上傳完成 , 使用 "重整功能" 圖會直接被刪除](https://github.com/numbersprotocol/capture-lite/issues/918)
+
 ## 0.47.0
 
 ### Added

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "io.numbersprotocol.capturelite"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 300
-        versionName "0.47.0"
+        versionCode 310
+        versionName "0.48.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "capture-lite",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.47.0",
+      "version": "0.48.0",
       "dependencies": {
         "@angular/animations": "^12.2.4",
         "@angular/cdk": "^12.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capture-lite",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "author": "numbersprotocol",
   "homepage": "https://numbersprotocol.io/",
   "scripts": {


### PR DESCRIPTION
Bump version to 0.48.0 by following [README Release section](https://github.com/numbersprotocol/capture-lite#release).