### PR TITLE
feat(dia-backend-wallet.service.ts): show custody wallet balance

### DIFF
--- a/src/app/shared/dia-backend/wallet/dia-backend-wallet.service.ts
+++ b/src/app/shared/dia-backend/wallet/dia-backend-wallet.service.ts
@@ -56,7 +56,7 @@ export class DiaBackendWalletService {
     );
   }
 
-  getManagedWallet$() {
+  getNumWallet$() {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers => {
         return this.httpClient.get<DiaBackendWallet>(
@@ -68,7 +68,7 @@ export class DiaBackendWalletService {
   }
 
   syncCaptBalance$() {
-    return this.getManagedWallet$().pipe(
+    return this.getNumWallet$().pipe(
       concatMap(diaBackendWallet =>
         forkJoin([
           this.preferences.setNumber(

--- a/src/app/shared/dia-backend/wallet/dia-backend-wallet.service.ts
+++ b/src/app/shared/dia-backend/wallet/dia-backend-wallet.service.ts
@@ -60,7 +60,7 @@ export class DiaBackendWalletService {
     return defer(() => this.authService.getAuthHeaders()).pipe(
       concatMap(headers => {
         return this.httpClient.get<DiaBackendWallet>(
-          `${BASE_URL}/api/v3/wallets/managed-wallet/`,
+          `${BASE_URL}/api/v3/wallets/num-wallet/`,
           { headers }
         );
       })
@@ -68,7 +68,7 @@ export class DiaBackendWalletService {
   }
 
   syncCaptBalance$() {
-    return this.getAssetWallet$().pipe(
+    return this.getManagedWallet$().pipe(
       concatMap(diaBackendWallet =>
         forkJoin([
           this.preferences.setNumber(


### PR DESCRIPTION
Update the api request url endpoint in `getManagedWallet$` to show NUM balance from custody/managed wallet instead of Capture wallet.

## Test Plan
Dev storage backend
![image](https://user-images.githubusercontent.com/35753861/153800938-4e929660-e373-4ef0-bb2e-ee34acd4d2f1.png)

Prod storage backend
<img width="1599" alt="image" src="https://user-images.githubusercontent.com/35753861/153819429-fa180d19-0cdb-404d-b530-23d4e1799491.png">

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1201813627329196) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
