### PR TITLE
Add num balance loading indicator

### DIFF
--- a/src/app/features/profile/profile.page.html
+++ b/src/app/features/profile/profile.page.html
@@ -14,17 +14,15 @@
       <div mat-line>NUM {{ t('balance') }}</div>
       <div mat-line>ERC20</div>
       <div class="num-balance">
-        <ng-container
-          *ngIf="networkConnected$ | ngrxPush; else balance_offline"
-        >
+        <ng-container *ngIf="networkConnected$ | ngrxPush; else balanceOffline">
           <ng-container
-            *ngIf="!(isLoadingBalance$ | ngrxPush); else balance_loading"
+            *ngIf="!(isLoadingBalance$ | ngrxPush); else balanceLoading"
           >
             $ {{ ethNumBalance$ | ngrxPush | number: '1.2-2' }}
           </ng-container>
         </ng-container>
-        <ng-template #balance_offline> --offline-- </ng-template>
-        <ng-template #balance_loading>
+        <ng-template #balanceOffline> --offline-- </ng-template>
+        <ng-template #balanceLoading>
           <mat-spinner diameter="30"></mat-spinner>
         </ng-template>
       </div>
@@ -34,11 +32,9 @@
       <div mat-line>NUM {{ t('balance') }}</div>
       <div mat-line>BEP20</div>
       <div class="num-balance">
-        <ng-container
-          *ngIf="networkConnected$ | ngrxPush; else balance_offline"
-        >
+        <ng-container *ngIf="networkConnected$ | ngrxPush; else balanceOffline">
           <ng-container
-            *ngIf="!(isLoadingBalance$ | ngrxPush); else balance_loading"
+            *ngIf="!(isLoadingBalance$ | ngrxPush); else balanceLoading"
           >
             $ {{ bscNumBalance$ | ngrxPush | number: '1.2-2' }}
           </ng-container>

--- a/src/app/features/profile/profile.page.html
+++ b/src/app/features/profile/profile.page.html
@@ -14,10 +14,19 @@
       <div mat-line>NUM {{ t('balance') }}</div>
       <div mat-line>ERC20</div>
       <div class="num-balance">
-        <ng-container *ngIf="networkConnected$ | ngrxPush; else offline">
-          $ {{ ethNumBalance$ | ngrxPush | number: '1.2-2' }}
+        <ng-container
+          *ngIf="networkConnected$ | ngrxPush; else balance_offline"
+        >
+          <ng-container
+            *ngIf="!(isLoadingBalance$ | ngrxPush); else balance_loading"
+          >
+            $ {{ ethNumBalance$ | ngrxPush | number: '1.2-2' }}
+          </ng-container>
         </ng-container>
-        <ng-template #offline> --offline-- </ng-template>
+        <ng-template #balance_offline> --offline-- </ng-template>
+        <ng-template #balance_loading>
+          <mat-spinner diameter="30"></mat-spinner>
+        </ng-template>
       </div>
     </mat-list-item>
     <mat-list-item>
@@ -25,10 +34,15 @@
       <div mat-line>NUM {{ t('balance') }}</div>
       <div mat-line>BEP20</div>
       <div class="num-balance">
-        <ng-container *ngIf="networkConnected$ | ngrxPush; else offline">
-          $ {{ bscNumBalance$ | ngrxPush | number: '1.2-2' }}
+        <ng-container
+          *ngIf="networkConnected$ | ngrxPush; else balance_offline"
+        >
+          <ng-container
+            *ngIf="!(isLoadingBalance$ | ngrxPush); else balance_loading"
+          >
+            $ {{ bscNumBalance$ | ngrxPush | number: '1.2-2' }}
+          </ng-container>
         </ng-container>
-        <ng-template #offline> --offline-- </ng-template>
       </div>
     </mat-list-item>
     <mat-list-item>

--- a/src/app/features/profile/profile.page.ts
+++ b/src/app/features/profile/profile.page.ts
@@ -37,6 +37,7 @@ export class ProfilePage {
   readonly ethNumBalance$ = this.diaBackendWalletService.ethNumBalance$;
   readonly bscNumBalance$ = this.diaBackendWalletService.bscNumBalance$;
   readonly networkConnected$ = this.diaBackendWalletService.networkConnected$;
+  readonly isLoadingBalance$ = this.diaBackendWalletService.isLoadingBalance$;
 
   constructor(
     private readonly database: Database,

--- a/src/app/shared/dia-backend/wallet/dia-backend-wallet.service.ts
+++ b/src/app/shared/dia-backend/wallet/dia-backend-wallet.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { defer, forkJoin } from 'rxjs';
-import { concatMap } from 'rxjs/operators';
+import { BehaviorSubject, defer, forkJoin } from 'rxjs';
+import { concatMap, tap } from 'rxjs/operators';
 import { NetworkService } from '../../network/network.service';
 import { PreferenceManager } from '../../preference-manager/preference-manager.service';
 import { DiaBackendAuthService } from '../auth/dia-backend-auth.service';
@@ -23,6 +23,8 @@ export class DiaBackendWalletService {
   );
 
   readonly networkConnected$ = this.networkService.connected$;
+
+  readonly isLoadingBalance$ = new BehaviorSubject<boolean>(false);
 
   constructor(
     private readonly httpClient: HttpClient,
@@ -68,6 +70,7 @@ export class DiaBackendWalletService {
   }
 
   syncCaptBalance$() {
+    this.isLoadingBalance$.next(true);
     return this.getNumWallet$().pipe(
       concatMap(diaBackendWallet =>
         forkJoin([
@@ -80,7 +83,10 @@ export class DiaBackendWalletService {
             diaBackendWallet.num_balance.bsc_num
           ),
         ])
-      )
+      ),
+      tap(() => {
+        this.isLoadingBalance$.next(false);
+      })
     );
   }
 }


### PR DESCRIPTION
See [NUM balance does not load instantly #1277](https://github.com/numbersprotocol/capture-lite/issues/1277) for more context.

## Test Plan
Demo: [before](https://www.youtube.com/watch?v=RISbs5wqb3c), [after](https://www.youtube.com/watch?v=RANjEGdR8Gk)

```bash
➜  capture-lite git:(feature-add-NUM-balance-loading-indicator) npm run test.ci

> capture-lite@0.48.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.48.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts

16 02 2022 12:40:01.660:INFO [karma-server]: Karma v6.3.16 server started at http://localhost:9876/
16 02 2022 12:40:01.661:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
16 02 2022 12:40:01.663:INFO [launcher]: Starting browser ChromeHeadless
16 02 2022 12:40:07.531:INFO [Chrome Headless 98.0.4758.80 (Mac OS 10.15.7)]: Connected on socket 1LYUyUTHK5-pkoraAAAB with id 68761361
Chrome Headless 98.0.4758.80 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.80 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.80 (Mac OS 10.15.7): Executed 213 of 213 (2 FAILED) (28.908 secs / 28.71 secs)
TOTAL: 2 FAILED, 211 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.03% ( 1727/3384 )
Branches     : 29.69% ( 288/970 )
Functions    : 40.7% ( 613/1506 )
Lines        : 52.97% ( 1560/2945 )
================================================================================
➜  capture-lite git:(feature-add-NUM-balance-loading-indicator)
```