### PR TITLE
fix(src/app/features/home/sending-post-capture): fix null message ove…

### DIFF
--- a/src/app/features/home/sending-post-capture/sending-post-capture.page.html
+++ b/src/app/features/home/sending-post-capture/sending-post-capture.page.html
@@ -19,7 +19,7 @@
           <mat-form-field appearance="outline">
             <mat-label>{{ t('.message') }}</mat-label>
             <textarea
-              [(ngModel)]="previewCaption"
+              [(ngModel)]="message"
               name="caption"
               ngModel
               matInput
@@ -75,7 +75,7 @@
     </mat-card>
 
     <button
-      (click)="send(previewCaption)"
+      (click)="send()"
       class="send-button"
       mat-raised-button
       color="primary"

--- a/src/app/features/home/sending-post-capture/sending-post-capture.page.ts
+++ b/src/app/features/home/sending-post-capture/sending-post-capture.page.ts
@@ -101,7 +101,7 @@ export class SendingPostCapturePage {
         asset_file: assetFileUrl,
         asset_file_thumbnail: assetFileUrl,
         sharable_copy: assetFileUrl,
-        caption: this.previewCaption,
+        caption: this.message !== '' ? this.message : asset.caption,
         source_transaction: {
           id: '',
           sender: asset.owner_name,
@@ -119,7 +119,7 @@ export class SendingPostCapturePage {
     shareReplay({ bufferSize: 1, refCount: true })
   );
 
-  previewCaption = '';
+  message = '';
 
   isPreview = false;
 
@@ -152,14 +152,14 @@ export class SendingPostCapturePage {
     }
   }
 
-  async send(captionText: string) {
+  async send() {
     const action$ = combineLatest([this.asset$, this.receiverEmail$]).pipe(
       first(),
       switchTap(([asset, contact]) =>
         this.diaBackendTransactionRepository.add$({
           assetId: asset.id,
           targetEmail: contact,
-          caption: captionText,
+          caption: this.message !== '' ? this.message : asset.caption,
           createContact: this.shouldCreateContact,
         })
       ),


### PR DESCRIPTION
Fix [[Issue] 在送 poscapture 時的 message 會自動帶入原先的 caption ike #1166](https://github.com/numbersprotocol/capture-lite/issues/1166). I add a check on frontend to pass in message as caption only if message is not empty. Otherwise I pass in the original asset caption. 

## Test plan
Demo video here: [Fix- 在送 poscapture 時的 message 會自動帶入原先的 caption ike](https://www.youtube.com/watch?v=xoaoENQEwfY), [make sure non-null message overwrites asset caption](https://youtu.be/0o___Lf9KXQ)
```bash
➜  capture-lite git:(fix-message-overwriting-caption-when-send) ✗ npm run test.ci

> capture-lite@0.48.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.48.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

21 02 2022 10:50:28.697:INFO [karma-server]: Karma v6.3.16 server started at http://localhost:9876/
21 02 2022 10:50:28.699:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
21 02 2022 10:50:28.702:INFO [launcher]: Starting browser ChromeHeadless
21 02 2022 10:50:34.697:INFO [Chrome Headless 98.0.4758.102 (Mac OS 10.15.7)]: Connected on socket A5YCSP3co8HzYlyzAAAB with id 66562527
Chrome Headless 98.0.4758.102 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.102 (Mac OS 10.15.7): Executed 213 of 213 (1 FAILED) (26.494 secs / 26.296 secs)
TOTAL: 1 FAILED, 212 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.86% ( 1719/3380 )
Branches     : 29.36% ( 286/974 )
Functions    : 40.53% ( 610/1505 )
Lines        : 52.81% ( 1553/2941 )
================================================================================
➜  capture-lite git:(fix-message-overwriting-caption-when-send) ✗ 
```