### PR TITLE
feat(sending-post-capture.page.ts): have message default to asset cap…

### DIFF
--- a/src/app/features/home/sending-post-capture/sending-post-capture.page.ts
+++ b/src/app/features/home/sending-post-capture/sending-post-capture.page.ts
@@ -140,6 +140,12 @@ export class SendingPostCapturePage {
     private readonly navController: NavController
   ) {}
 
+  ionViewWillEnter() {
+    this.asset$.pipe(untilDestroyed(this)).subscribe(asset => {
+      this.message = asset.caption;
+    });
+  }
+
   preview() {
     this.isPreview = true;
   }


### PR DESCRIPTION
Thanks for Charles' suggestion. Have message default to asset caption when sending Capture.

## Test Plan
Demo video: [before](https://www.youtube.com/watch?v=0o___Lf9KXQ), [after](https://www.youtube.com/watch?v=dKcyiWoS3MY)

```bash
➜  capture-lite git:(feature-default-message-to-caption-when-send) ✗ npm run test.ci

> capture-lite@0.49.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.49.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

22 02 2022 17:08:03.148:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
22 02 2022 17:08:03.148:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
22 02 2022 17:08:03.151:INFO [launcher]: Starting browser ChromeHeadless
22 02 2022 17:08:09.206:INFO [Chrome Headless 98.0.4758.102 (Mac OS 10.15.7)]: Connected on socket z4EJTDgis8FkaQ2lAAAB with id 35798524
Chrome Headless 98.0.4758.102 (Mac OS 10.15.7): Executed 148 of 213 SUCCESS (0 secs / 7.153 secs)
Chrome Headless 98.0.4758.102 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
Chrome Headless 98.0.4758.102 (Mac OS 10.15.7): Executed 213 of 213 (1 FAILED) (26.837 secs / 26.647 secs)
TOTAL: 1 FAILED, 212 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.1% ( 1735/3395 )
Branches     : 29.86% ( 292/978 )
Functions    : 40.66% ( 614/1510 )
Lines        : 53.04% ( 1568/2956 )
================================================================================
➜  capture-lite git:(feature-default-message-to-caption-when-send)
```