### PR TITLE
feat(src/app/features/home/details): display edit icon when no caption

### DIFF
--- a/src/app/features/home/details/details.page.html
+++ b/src/app/features/home/details/details.page.html
@@ -102,7 +102,13 @@
                   {{ caption }}
                 </ion-label>
                 <ng-template #emptyCaption>
-                  <ion-label> No Caption </ion-label>
+                  <ion-label>
+                    No Caption
+                    <ion-icon
+                      name="pencil-outline"
+                      id="caption-edit-icon"
+                    ></ion-icon>
+                  </ion-label>
                 </ng-template>
               </ion-item>
             </ng-container>

--- a/src/app/features/home/details/details.page.scss
+++ b/src/app/features/home/details/details.page.scss
@@ -43,4 +43,8 @@
   .text-center {
     text-align: center;
   }
+
+  #caption-edit-icon {
+    transform: translateY(3px);
+  }
 }


### PR DESCRIPTION
Thanks for Charles’ suggestion. Add an edit icon when the asset caption is empty to inform users that they could tap to edit.

## Test Plan
<img width="472" alt="image" src="https://user-images.githubusercontent.com/35753861/155103106-16e629c7-5840-44d7-b18b-5a5a7f70e698.png">


```bash
➜  capture-lite git:(feature-caption-edit-icon) ✗ npm run test.ci

> capture-lite@0.49.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.49.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts

22 02 2022 17:17:51.881:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
22 02 2022 17:17:51.882:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
22 02 2022 17:17:51.884:INFO [launcher]: Starting browser ChromeHeadless
22 02 2022 17:17:58.280:INFO [Chrome Headless 98.0.4758.102 (Mac OS 10.15.7)]: Connected on socket WbSHN_KlqJNOovhlAAAB with id 44941128
Chrome Headless 98.0.4758.102 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.102 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
Chrome Headless 98.0.4758.102 (Mac OS 10.15.7): Executed 193 of 213 (2 FAILED) (0 secs / 27.696 secs)
Chrome Headless 98.0.4758.102 (Mac OS 10.15.7): Executed 213 of 213 (2 FAILED) (28.014 secs / 27.815 secs)
TOTAL: 2 FAILED, 211 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.31% ( 1741/3393 )
Branches     : 30.06% ( 294/978 )
Functions    : 40.92% ( 617/1508 )
Lines        : 53.25% ( 1573/2954 )
================================================================================
➜  capture-lite git:(feature-caption-edit-icon) ✗
```