### PR TITLE
feat: replace 'No Caption' with 'Click to Edit Caption' on Capture de…

### DIFF
--- a/src/app/features/home/details/details.page.html
+++ b/src/app/features/home/details/details.page.html
@@ -103,7 +103,7 @@
                 </ion-label>
                 <ng-template #emptyCaption>
                   <ion-label>
-                    No Caption
+                    {{ 'clickToEditCaption' | transloco }}
                     <ion-icon
                       name="pencil-outline"
                       id="caption-edit-icon"

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -20,6 +20,7 @@
   "cancel": "Cancel",
   "ok": "Ok",
   "emptyInbox": "Empty Inbox",
+  "clickToEditCaption": "Click to Edit Caption",
   "editCaption": "Edit Caption",
   "selectAPublisher": "Select a Publisher",
   "about": "About",

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -20,6 +20,7 @@
   "cancel": "取消",
   "ok": "確認",
   "emptyInbox": "空收件匣",
+  "clickToEditCaption": "點擊以編輯標題",
   "editCaption": "編輯標題",
   "selectAPublisher": "選擇發佈者",
   "about": "關於",


### PR DESCRIPTION
Replace 'No Caption' with 'Click to Edit Caption' on Capture details page to make it obvious that the caption is editable. Thanks for @tammyyang's feedback.

## Test Plan
<img width="419" alt="image" src="https://user-images.githubusercontent.com/35753861/155676572-baa9628e-ca0c-4d83-a26e-4139401db5b6.png">

```bash
➜  capture-lite git:(feature-update-caption-edit-help-text) ✗ npm run test.ci                                                                           

> capture-lite@0.49.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.49.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

25 02 2022 15:53:22.972:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
25 02 2022 15:53:22.973:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
25 02 2022 15:53:22.976:INFO [launcher]: Starting browser ChromeHeadless
25 02 2022 15:53:29.694:INFO [Chrome Headless 98.0.4758.109 (Mac OS 10.15.7)]: Connected on socket aj37pHeI8Xk1QcZ0AAAB with id 88279526
Chrome Headless 98.0.4758.109 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.109 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
Chrome Headless 98.0.4758.109 (Mac OS 10.15.7): Executed 213 of 213 (2 FAILED) (26.906 secs / 26.704 secs)
TOTAL: 2 FAILED, 211 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.84% ( 1726/3395 )
Branches     : 29.35% ( 287/978 )
Functions    : 40.4% ( 610/1510 )
Lines        : 52.77% ( 1560/2956 )
================================================================================
➜  capture-lite git:(feature-update-caption-edit-help-text) ✗ 
```

