### PR TITLE
fix(app/features/home/transaction/transaction-details): fix activity …

### DIFF
--- a/src/app/features/home/transaction/transaction-details/transaction-details.page.html
+++ b/src/app/features/home/transaction/transaction-details/transaction-details.page.html
@@ -10,15 +10,10 @@
   </h4>
   <mat-card class="transaction-card">
     <mat-card-content class="row">
-      <mat-label> {{ (transaction$ | ngrxPush)?.asset?.id }}</mat-label>
-      <button
-        *ngrxLet="status$ as status"
-        [class]="status"
-        mat-stroked-button
-        disableRipple
-      >
-        {{ t('transactionState.' + status) }}
-      </button>
+      <mat-label>
+        {{ t('digitalAsset') }} ID:
+        {{ (transaction$ | ngrxPush)?.asset?.id }}
+      </mat-label>
     </mat-card-content>
     <img
       decoding="async"
@@ -32,6 +27,16 @@
       <mat-label>
         {{ t('receiver') }}: {{ (transaction$ | ngrxPush)?.receiver_email }}
       </mat-label>
+    </mat-card-content>
+    <mat-card-content class="column">
+      <button
+        *ngrxLet="status$ as status"
+        [class]="status"
+        mat-stroked-button
+        disableRipple
+      >
+        {{ t('transactionState.' + status) }}
+      </button>
     </mat-card-content>
   </mat-card>
 </div>

--- a/src/app/features/home/transaction/transaction-details/transaction-details.page.scss
+++ b/src/app/features/home/transaction/transaction-details/transaction-details.page.scss
@@ -88,3 +88,7 @@ form mat-form-field {
 .spacer {
   flex: 1 1 auto;
 }
+
+mat-label {
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
Fix activity details cid text overflow. See [[Issue] activity details cid 超出顯示區 #1167](https://github.com/numbersprotocol/capture-lite/issues/1167). 

I also moved the transaction state button to the bottom.

## Test Plan
Before: 
![](https://user-images.githubusercontent.com/35753861/155836221-881c2200-9056-4262-8792-747aabbe0cf0.png)
![](https://user-images.githubusercontent.com/35753861/155836236-e7b987e4-47d1-43af-a4b7-e77995a62f51.png)

After:
![](https://user-images.githubusercontent.com/35753861/155836212-aeb959af-4e15-4826-981b-b9bc3b356e06.png)

```bash
➜  capture-lite git:(fix-activity-details-cid-text-overflow) ✗ npm run test.ci

> capture-lite@0.49.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.49.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

26 02 2022 16:23:23.727:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
26 02 2022 16:23:23.728:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
26 02 2022 16:23:23.732:INFO [launcher]: Starting browser ChromeHeadless
26 02 2022 16:23:29.774:INFO [Chrome Headless 98.0.4758.109 (Mac OS 10.15.7)]: Connected on socket zwt3OSgLwBdnzmQfAAAB with id 81446853
Chrome Headless 98.0.4758.109 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.109 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.109 (Mac OS 10.15.7): Executed 195 of 213 (2 FAILED) (0 secs / 27.34 secs)
Chrome Headless 98.0.4758.109 (Mac OS 10.15.7): Executed 213 of 213 (2 FAILED) (27.613 secs / 27.415 secs)
TOTAL: 2 FAILED, 211 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.1% ( 1735/3395 )
Branches     : 29.75% ( 291/978 )
Functions    : 40.66% ( 614/1510 )
Lines        : 53.04% ( 1568/2956 )
================================================================================
➜  capture-lite git:(fix-activity-details-cid-text-overflow) ✗
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1201888677118290) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
