### PR TITLE
Feature remove add to contacts checkbox when receiver already in contacts

### DIFF
--- a/src/app/features/home/sending-post-capture/sending-post-capture.page.html
+++ b/src/app/features/home/sending-post-capture/sending-post-capture.page.html
@@ -96,7 +96,7 @@
       </div>
     </button>
 
-    <div class="checkbox">
+    <div class="checkbox" *ngIf="!contactAlreadyExists">
       <ion-checkbox
         slot="start"
         [(ngModel)]="shouldCreateContact"

--- a/src/app/features/home/sending-post-capture/sending-post-capture.page.html
+++ b/src/app/features/home/sending-post-capture/sending-post-capture.page.html
@@ -97,10 +97,10 @@
     </button>
 
     <div class="checkbox" *ngIf="!contactAlreadyExists">
-      <ion-checkbox
-        slot="start"
+      <mat-checkbox
+        color="primary"
         [(ngModel)]="shouldCreateContact"
-      ></ion-checkbox>
+      ></mat-checkbox>
       <ion-label>{{ t('addTheReceiverToContacts') }}</ion-label>
     </div>
   </ng-container>


### PR DESCRIPTION
* Hide the add to contacts checkbox if the receiver is already in user's contacts
* Update the appearance of add to contacts checkbox 

## Test Plan
### If the receiver is already in user's contacts:
![](https://user-images.githubusercontent.com/35753861/156368985-ce866b0f-7803-4f9a-9f4b-6544bc4bcd6c.png)

### Checkbox appearance:
Before:
![](https://user-images.githubusercontent.com/35753861/156368776-0ffbf8aa-fdf0-4f51-a2c7-617c6935c630.png)

After: 
![](https://user-images.githubusercontent.com/35753861/156368657-9c622ef0-8440-4427-a12d-d1a1fb4b6216.png)

```bash
➜  capture-lite git:(feature-remove-add-to-contacts-checkbox-when-receiver-already-in-contacts) ✗ npm run test.ci

> capture-lite@0.49.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.49.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

02 03 2022 21:01:33.042:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
02 03 2022 21:01:33.043:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
02 03 2022 21:01:33.045:INFO [launcher]: Starting browser ChromeHeadless
02 03 2022 21:01:39.554:INFO [Chrome Headless 98.0.4758.109 (Mac OS 10.15.7)]: Connected on socket M65WgFTgTT2utOnHAAAB with id 86090238
Chrome Headless 98.0.4758.109 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.109 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:154115:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 98.0.4758.109 (Mac OS 10.15.7): Executed 213 of 213 (2 FAILED) (27.43 secs / 27.234 secs)
TOTAL: 2 FAILED, 211 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51% ( 1735/3402 )
Branches     : 29.49% ( 289/980 )
Functions    : 40.54% ( 613/1512 )
Lines        : 52.96% ( 1568/2961 )
================================================================================
➜  capture-lite git:(feature-remove-add-to-contacts-checkbox-when-receiver-already-in-contacts) ✗
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1201908255674147) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
