### PR TITLE
feat(detail.page.ts): point blockchain certificate to the new asset p…

### DIFF
--- a/src/app/features/home/details/details.page.ts
+++ b/src/app/features/home/details/details.page.ts
@@ -458,7 +458,7 @@ export class DetailsPage {
         concatMap(([detailedCapture, token]) =>
           defer(() =>
             Browser.open({
-              url: `https://authmedia.net/dia-certificate?mid=${detailedCapture.id}&token=${token}`,
+              url: `https://authmedia.net/asset-profile?cid=${detailedCapture.id}&token=${token}`,
               toolbarColor: '#564dfc',
             })
           )


### PR DESCRIPTION
Point blockchain certificate to the new asset profile page.

## Test Plan
Demo video: https://youtu.be/DvNPQa6JTSM

```bash
➜  capture-lite git:(feature-link-to-new-asset-profile-page) ✗ npm run test.ci

> capture-lite@0.50.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.50.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

Compiling @angular/core/testing : es2015 as esm2015
Compiling @angular/platform-browser/testing : es2015 as esm2015
Compiling @angular/compiler/testing : es2015 as esm2015
Compiling @angular/common/testing : es2015 as esm2015
Compiling @angular/common/http/testing : es2015 as esm2015
Compiling @angular/material/icon/testing : es2015 as esm2015
Compiling @angular/router/testing : es2015 as esm2015
Compiling @angular/platform-browser-dynamic/testing : es2015 as esm2015
15 03 2022 15:12:01.943:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
15 03 2022 15:12:01.944:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
15 03 2022 15:12:01.946:INFO [launcher]: Starting browser ChromeHeadless
15 03 2022 15:12:10.064:INFO [Chrome Headless 99.0.4844.51 (Mac OS 10.15.7)]: Connected on socket qKJPY-14WUfqrg_jAAAB with id 19207554
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3729:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3729:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3729:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7) MediaStore should check if file exists FAILED
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3729:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3729:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7) MediaStore should write file with Base64 FAILED
        Error: Entry does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:154310:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: 'NG0304: 'app-network-action-orders' is not a known element:
1. If 'app-network-action-orders' is an Angular component, then verify that it is part of this module.
2. If 'app-network-action-orders' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 112 of 219 (4 FAILED) (0 secs / 28.043 secs)
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 146 of 219 (4 FAILED) (0 secs / 28.213 secs)
15 03 2022 15:12:38.909:WARN [web-server]: 404: /_karma_webpack_/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22
ERROR: 'ERROR', HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true: 404 Not Found', error: 'NOT FOUND'}
ERROR: HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/action', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/action: 404 Not Found', error: 'NOT FOUND'}
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 219 of 219 (4 FAILED) (28.719 secs / 28.506 secs)
TOTAL: 4 FAILED, 215 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.2% ( 1816/3547 )
Branches     : 29.16% ( 296/1015 )
Functions    : 40.31% ( 632/1568 )
Lines        : 53.04% ( 1641/3094 )
================================================================================
➜  capture-lite git:(feature-link-to-new-asset-profile-page) ✗ 
```


