### PR TITLE
fix: display erro and check network connection on wallets and transfe…

### DIFF
--- a/src/app/features/home/details/actions/actions.page.ts
+++ b/src/app/features/home/details/actions/actions.page.ts
@@ -1,4 +1,3 @@
-import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -97,28 +96,18 @@ export class ActionsPage {
 
   createOrder$(appName: string, actionArgs: any) {
     return this.storeService.createNetworkAppOrder(appName, actionArgs).pipe(
-      catchError((err: unknown) => {
-        return this.errorService.toastError$(err);
-      }),
+      catchError((err: unknown) =>
+        this.errorService.toastDIABackendError$(err)
+      ),
       isNonNullable()
     );
   }
 
   confirmOrder$(id: string) {
     return this.storeService.confirmNetworkAppOrder(id).pipe(
-      catchError((err: unknown) => {
-        if (err instanceof HttpErrorResponse) {
-          const errorType = err.error.error?.type;
-          if (
-            errorType === 'insufficient_fund' ||
-            errorType === 'order_expired'
-          )
-            return this.errorService.toastError$(
-              this.translocoService.translate(`error.diaBackend.${errorType}`)
-            );
-        }
-        return this.errorService.toastError$(err);
-      }),
+      catchError((err: unknown) =>
+        this.errorService.toastDIABackendError$(err)
+      ),
       isNonNullable()
     );
   }

--- a/src/app/features/home/details/actions/actions.page.ts
+++ b/src/app/features/home/details/actions/actions.page.ts
@@ -97,7 +97,7 @@ export class ActionsPage {
   createOrder$(appName: string, actionArgs: any) {
     return this.storeService.createNetworkAppOrder(appName, actionArgs).pipe(
       catchError((err: unknown) =>
-        this.errorService.toastDIABackendError$(err)
+        this.errorService.toastDiaBackendError$(err)
       ),
       isNonNullable()
     );
@@ -106,7 +106,7 @@ export class ActionsPage {
   confirmOrder$(id: string) {
     return this.storeService.confirmNetworkAppOrder(id).pipe(
       catchError((err: unknown) =>
-        this.errorService.toastDIABackendError$(err)
+        this.errorService.toastDiaBackendError$(err)
       ),
       isNonNullable()
     );

--- a/src/app/features/profile/profile.page.ts
+++ b/src/app/features/profile/profile.page.ts
@@ -9,7 +9,6 @@ import { BlockingActionService } from '../../shared/blocking-action/blocking-act
 import { ConfirmAlert } from '../../shared/confirm-alert/confirm-alert.service';
 import { Database } from '../../shared/database/database.service';
 import { DiaBackendAuthService } from '../../shared/dia-backend/auth/dia-backend-auth.service';
-import { DiaBackendWalletService } from '../../shared/dia-backend/wallet/dia-backend-wallet.service';
 import { ErrorService } from '../../shared/error/error.service';
 import { MediaStore } from '../../shared/media/media-store/media-store.service';
 import { PreferenceManager } from '../../shared/preference-manager/preference-manager.service';
@@ -25,7 +24,6 @@ export class ProfilePage {
   readonly email$ = this.diaBackendAuthService.email$;
   readonly phoneVerified$ = this.diaBackendAuthService.phoneVerified$;
   readonly emailVerified$ = this.diaBackendAuthService.emailVerified$;
-  readonly networkConnected$ = this.diaBackendWalletService.networkConnected$;
 
   constructor(
     private readonly database: Database,
@@ -38,8 +36,7 @@ export class ProfilePage {
     private readonly confirmAlert: ConfirmAlert,
     private readonly alertController: AlertController,
     private readonly router: Router,
-    private readonly route: ActivatedRoute,
-    private readonly diaBackendWalletService: DiaBackendWalletService
+    private readonly route: ActivatedRoute
   ) {}
 
   ionViewWillEnter() {

--- a/src/app/features/wallets/transfer/transfer.page.ts
+++ b/src/app/features/wallets/transfer/transfer.page.ts
@@ -142,7 +142,7 @@ export class TransferPage {
               }
             }
           }
-          return this.errorService.toastDIABackendError$(err);
+          return this.errorService.toastDiaBackendError$(err);
         }),
         untilDestroyed(this)
       )
@@ -165,7 +165,7 @@ export class TransferPage {
       .pipe(
         tap(() => this.openTransferRequestSentDialog()),
         catchError((err: unknown) =>
-          this.errorService.toastDIABackendError$(err)
+          this.errorService.toastDiaBackendError$(err)
         ),
         finalize(() => dialogRef.close()),
         untilDestroyed(this)

--- a/src/app/features/wallets/wallets.page.html
+++ b/src/app/features/wallets/wallets.page.html
@@ -55,7 +55,7 @@
           color="#7E7E7E"
           fill="outline"
           size="small"
-          [routerLink]="['transfer', 'deposit']"
+          (click)="onDepositWithdrawBtnClick('deposit')"
           >{{ t('wallets.deposit') }}</ion-button
         >
         <ion-button
@@ -63,7 +63,7 @@
           color="#7E7E7E"
           fill="outline"
           size="small"
-          [routerLink]="['transfer', 'withdraw']"
+          (click)="onDepositWithdrawBtnClick('withdraw')"
           >{{ t('wallets.withdraw') }}</ion-button
         >
       </ion-row>

--- a/src/app/shared/error/error.service.ts
+++ b/src/app/shared/error/error.service.ts
@@ -62,6 +62,23 @@ export class ErrorService {
         concatMapTo(EMPTY)
       );
   }
+
+  toastDIABackendError$(err: unknown) {
+    if (err instanceof HttpErrorResponse) {
+      const errorType = err.error.error?.type;
+      if (
+        errorType === 'invalid_network_app_name' ||
+        errorType === 'insufficient_fund' ||
+        errorType === 'order_expired' ||
+        errorType === 'unable_to_confirm_order' ||
+        errorType === 'unpaid_num_exceed_threshold'
+      )
+        return this.toastError$(
+          this.translocoService.translate(`error.diaBackend.${errorType}`)
+        );
+    }
+    return this.toastError$(err);
+  }
 }
 
 export enum HttpErrorCode {

--- a/src/app/shared/error/error.service.ts
+++ b/src/app/shared/error/error.service.ts
@@ -63,7 +63,7 @@ export class ErrorService {
       );
   }
 
-  toastDIABackendError$(err: unknown) {
+  toastDiaBackendError$(err: unknown) {
     if (err instanceof HttpErrorResponse) {
       const errorType = err.error.error?.type;
       if (

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -206,12 +206,17 @@
       "user_is_email_verified": "The email address has beed verified",
       "user_not_found": "There is no account registered with the email address",
       "asset_is_being_minted": "Asset is being minted",
-      "insufficient_fund": "Insufficient NUM token",
-      "order_expired": "Order expired. Please create a new order and confirm it within 5 minutes."
+      "insufficient_fund": "Insufficient NUM token.",
+      "order_expired": "Order expired. Please create a new order and confirm it within 5 minutes.",
+      "unable_to_confirm_order": "Unable to confirm order. Please try again.",
+      "unpaid_num_exceed_threshold": "Too much unpaid NUM. Please contact us with email to restore account functionality.",
+      "invalid_network_app_name": "Invalid network app."
     },
     "wallets": {
       "emptyTransferAmount": "Please enter a valid transfer amount.",
-      "insufficientFund": "Insufficient NUM token."
+      "cannotRefreshBalance": "Error refreshing balance.",
+      "noNetworkConnectionCannotRefreshBalance": "No internet connection. Cannot refresh balance.",
+      "insufficientFundWithRequiredBalance": "Insufficient NUM token. Need at least {{requiredBalance}} NUM."
     }
   },
   "transactionState": {

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -215,7 +215,7 @@
     "wallets": {
       "emptyTransferAmount": "請輸入有效轉帳金額。",
       "cannotRefreshBalance": "刷新餘額時發生錯誤。",
-      "noNetworkConnectionCannotRefreshBalance": "沒有網絡連接，無法刷新餘額。",
+      "noNetworkConnectionCannotRefreshBalance": "沒有網路連接，無法刷新餘額。",
       "insufficientFundWithRequiredBalance": "NUM 餘額不足。需要至少 {{requiredBalance}} NUM"
     }
   },

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -206,12 +206,17 @@
       "user_is_email_verified": "此電子郵件已驗證",
       "user_not_found": "此電子郵件尚未註冊 Capture 帳號",
       "asset_is_being_minted": "NFT 代幣鑄造中",
-      "insufficient_fund": "NUM 餘額不足",
-      "order_expired": "訂單已過期。請創建新訂單並在 5 分鐘內確認。"
+      "insufficient_fund": "NUM 餘額不足。",
+      "order_expired": "訂單已過期。請創建新訂單並在 5 分鐘內確認。",
+      "unable_to_confirm_order": "無法確認訂單。請再試一次。",
+      "unpaid_num_exceed_threshold": "太多未付的 NUM。請通過電子郵件與我們聯繫以恢復帳戶功能。",
+      "invalid_network_app_name": "無效的網絡動作。"
     },
     "wallets": {
       "emptyTransferAmount": "請輸入有效轉帳金額。",
-      "insufficientFund": "NUM 餘額不足。"
+      "cannotRefreshBalance": "刷新餘額時發生錯誤。",
+      "noNetworkConnectionCannotRefreshBalance": "沒有網絡連接，無法刷新餘額。",
+      "insufficientFundWithRequiredBalance": "NUM 餘額不足。需要至少 {{requiredBalance}} NUM"
     }
   },
   "transactionState": {


### PR DESCRIPTION
* Add error handling logic to wallets page and transfer page
  * If the user doesn't have enough num for transfer operation, exactly how much num is needed will be displayed
* Add network connection check to wallet page
  * Prevent user from visiting transfer page if there's no internet connection
  * Display network connection error if user try to refresh balance when no internet connection
* Add `toastDIABackendError$` in ErrorService as a centralized place for translating DIA backend related errors

## Test Plan
![](https://user-images.githubusercontent.com/35753861/158378231-8134701a-2106-4781-a8b3-b7558ebea45c.png)

```bash
➜  capture-lite git:(fix-error-display-and-connection-check-on-wallets-transfer-page) ✗ npm run test.ci

> capture-lite@0.50.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.50.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

15 03 2022 20:32:43.934:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
15 03 2022 20:32:43.935:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
15 03 2022 20:32:43.936:INFO [launcher]: Starting browser ChromeHeadless
15 03 2022 20:32:50.151:INFO [Chrome Headless 99.0.4844.51 (Mac OS 10.15.7)]: Connected on socket qeRO7mkiFi-Z3_xJAAAB with id 99983682
ERROR: 'NG0304: 'app-network-action-orders' is not a known element:
1. If 'app-network-action-orders' is an Angular component, then verify that it is part of this module.
2. If 'app-network-action-orders' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: '<ion-refresher> must be used inside an <ion-content>'
ERROR: TypeError: config.get is not a function
TypeError: config.get is not a function
    at removeEventListener (http://localhost:9876/_karma_webpack_/vendor.js:178721:26)
    at SegmentButton.disconnectedCallback (http://localhost:9876/_karma_webpack_/node_modules_ionic_core_dist_esm_ion-segment_2_entry_js.js:484:62)
    at safeCall (http://localhost:9876/_karma_webpack_/vendor.js:180876:30)
    at disconnectedCallback (http://localhost:9876/_karma_webpack_/vendor.js:181560:7)
    at http://localhost:9876/_karma_webpack_/vendor.js:181666:23
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
    at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
    at NgZone.runOutsideAngular (http://localhost:9876/_karma_webpack_/vendor.js:92373:28), undefined
ERROR: TypeError: config.get is not a function
TypeError: config.get is not a function
    at removeEventListener (http://localhost:9876/_karma_webpack_/vendor.js:178721:26)
    at SegmentButton.disconnectedCallback (http://localhost:9876/_karma_webpack_/node_modules_ionic_core_dist_esm_ion-segment_2_entry_js.js:484:62)
    at safeCall (http://localhost:9876/_karma_webpack_/vendor.js:180876:30)
    at disconnectedCallback (http://localhost:9876/_karma_webpack_/vendor.js:181560:7)
    at http://localhost:9876/_karma_webpack_/vendor.js:181666:23
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
    at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
    at NgZone.runOutsideAngular (http://localhost:9876/_karma_webpack_/vendor.js:92373:28), undefined
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 161 of 219 (2 FAILED) (0 secs / 26.387 secs)
15 03 2022 20:33:17.150:WARN [web-server]: 404: /_karma_webpack_/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%
ERROR: 'ERROR', HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true: 404 Not Found', error: 'NOT FOUND'}
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 213 of 219 (2 FAILED) (0 secs / 26.714 secs)
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 219 of 219 (2 FAILED) (26.962 secs / 26.726 secs)
TOTAL: 2 FAILED, 217 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.17% ( 1820/3557 )
Branches     : 29.17% ( 297/1018 )
Functions    : 40.24% ( 633/1573 )
Lines        : 53.03% ( 1644/3100 )
================================================================================
➜  capture-lite git:(fix-error-display-and-connection-check-on-wallets-transfer-page) ✗
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1201971563498224) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
