### PR TITLE
feat: support points system and connect it to the backend and hide buy NUM button

### DIFF
--- a/src/app/features/wallets/wallets.page.html
+++ b/src/app/features/wallets/wallets.page.html
@@ -43,7 +43,7 @@
         <span
           class="bep20-points"
           *ngIf="!(isLoadingBalance$ | ngrxPush); else balanceLoading"
-          >{{ points | number: '1.2-2' }}</span
+          >{{ points$ | ngrxPush | number: '1.2-2' }}</span
         >
       </ion-row>
       <ion-row id="buy-deposit-withdraw-row">

--- a/src/app/features/wallets/wallets.page.html
+++ b/src/app/features/wallets/wallets.page.html
@@ -47,7 +47,11 @@
         >
       </ion-row>
       <ion-row id="buy-deposit-withdraw-row">
-        <ion-button id="buy-num-btn" size="small" class="num-operation-btn"
+        <ion-button
+          hidden
+          id="buy-num-btn"
+          size="small"
+          class="num-operation-btn"
           >{{ t('buy') }} NUM</ion-button
         >
         <ion-button

--- a/src/app/features/wallets/wallets.page.ts
+++ b/src/app/features/wallets/wallets.page.ts
@@ -3,14 +3,25 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatIconRegistry } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { DomSanitizer } from '@angular/platform-browser';
+import { Router } from '@angular/router';
 import { Plugins } from '@capacitor/core';
 import { TranslocoService } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BehaviorSubject } from 'rxjs';
-import { concatMap, first, map, switchMap } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, forkJoin } from 'rxjs';
+import {
+  catchError,
+  concatMap,
+  finalize,
+  first,
+  map,
+  switchMap,
+  tap,
+} from 'rxjs/operators';
 import { WebCryptoApiSignatureProvider } from '../../shared/collector/signature/web-crypto-api-signature-provider/web-crypto-api-signature-provider.service';
 import { ConfirmAlert } from '../../shared/confirm-alert/confirm-alert.service';
+import { DiaBackendAuthService } from '../../shared/dia-backend/auth/dia-backend-auth.service';
 import { DiaBackendWalletService } from '../../shared/dia-backend/wallet/dia-backend-wallet.service';
+import { ErrorService } from '../../shared/error/error.service';
 import { ExportPrivateKeyModalComponent } from '../../shared/export-private-key-modal/export-private-key-modal.component';
 
 const { Browser, Clipboard } = Plugins;
@@ -27,27 +38,29 @@ export class WalletsPage {
 
   readonly bscNumBalance$ =
     this.diaBackendWalletService.assetWalletBscNumBalance$;
-  readonly points = 0;
+  readonly points$ = this.diaBackendAuthService.points$;
 
-  readonly totalBalance$ = this.bscNumBalance$.pipe(
-    map(num => num + this.points)
-  );
+  readonly totalBalance$ = new BehaviorSubject<number>(0);
 
   readonly publicKey$ = this.webCryptoApiSignatureProvider.publicKey$;
   readonly privateKey$ = this.webCryptoApiSignatureProvider.privateKey$;
   readonly assetWalletAddr$ = this.diaBackendWalletService.assetWalletAddr$;
 
   readonly isLoadingBalance$ = new BehaviorSubject<boolean>(false);
+  readonly networkConnected$ = this.diaBackendWalletService.networkConnected$;
 
   constructor(
     private readonly diaBackendWalletService: DiaBackendWalletService,
+    private readonly diaBackendAuthService: DiaBackendAuthService,
     private readonly matIconRegistry: MatIconRegistry,
     private readonly domSanitizer: DomSanitizer,
     private readonly snackBar: MatSnackBar,
     private readonly translocoService: TranslocoService,
     private readonly webCryptoApiSignatureProvider: WebCryptoApiSignatureProvider,
     private readonly confirmAlert: ConfirmAlert,
-    private readonly dialog: MatDialog
+    private readonly dialog: MatDialog,
+    private readonly errorService: ErrorService,
+    private readonly router: Router
   ) {
     this.matIconRegistry.addSvgIcon(
       'wallet',
@@ -55,6 +68,16 @@ export class WalletsPage {
         '../../../assets/images/wallet.svg'
       )
     );
+
+    combineLatest([this.bscNumBalance$, this.points$])
+      .pipe(
+        first(),
+        map(
+          ([bscNumBalance, points]) => Number(bscNumBalance) + Number(points)
+        ),
+        untilDestroyed(this)
+      )
+      .subscribe(totalBalance => this.totalBalance$.next(totalBalance));
   }
 
   openNUMTransactionHistory() {
@@ -74,9 +97,58 @@ export class WalletsPage {
 
   async refreshBalance(event: Event) {
     (<CustomEvent>event).detail.complete();
-    this.isLoadingBalance$.next(true);
-    await this.diaBackendWalletService.syncAssetWalletBalance$().toPromise();
-    this.isLoadingBalance$.next(false);
+    this.networkConnected$
+      .pipe(
+        first(),
+        concatMap(networkConnected => {
+          if (!networkConnected) {
+            return this.errorService.toastError$(
+              this.translocoService.translate(
+                `error.wallets.noNetworkConnectionCannotRefreshBalance`
+              )
+            );
+          }
+          this.isLoadingBalance$.next(true);
+          return forkJoin([
+            this.diaBackendWalletService.syncAssetWalletBalance$(),
+            this.diaBackendAuthService.syncProfile$(),
+          ]).pipe(
+            tap(async ([assetWallet, _]) => {
+              this.totalBalance$.next(
+                Number(assetWallet[1]) +
+                  (await this.diaBackendAuthService.getPoints())
+              );
+            }),
+            catchError(() =>
+              this.errorService.toastError$(
+                this.translocoService.translate(
+                  `error.wallets.cannotRefreshBalance`
+                )
+              )
+            ),
+            finalize(() => this.isLoadingBalance$.next(false))
+          );
+        }),
+        untilDestroyed(this)
+      )
+      .subscribe();
+  }
+
+  async onDepositWithdrawBtnClick(mode: 'deposit' | 'withdraw') {
+    this.networkConnected$
+      .pipe(
+        first(),
+        concatMap(networkConnected => {
+          if (!networkConnected) {
+            return this.errorService.toastError$(
+              this.translocoService.translate(`error.internetError`)
+            );
+          }
+          return this.router.navigate(['wallets', 'transfer', mode]);
+        }),
+        untilDestroyed(this)
+      )
+      .subscribe();
   }
 
   async copyToClipboard(value: string) {

--- a/src/app/shared/dia-backend/auth/dia-backend-auth.service.ts
+++ b/src/app/shared/dia-backend/auth/dia-backend-auth.service.ts
@@ -67,6 +67,8 @@ export class DiaBackendAuthService {
     PrefKeys.EMAIL_VERIFIED
   );
 
+  readonly points$ = this.preferences.getNumber$(PrefKeys.POINTS);
+
   constructor(
     private readonly httpClient: HttpClient,
     private readonly languageService: LanguageService,
@@ -268,6 +270,7 @@ export class DiaBackendAuthService {
           this.setEmail(response.email),
           this.setPhoneVerfied(response.phone_verified),
           this.setEmailVerfied(response.email_verified),
+          this.setPoints(Number(response.user_wallet.points)),
         ]);
       })
     );
@@ -337,6 +340,14 @@ export class DiaBackendAuthService {
   async getEmailVerified() {
     return this.preferences.getBoolean(PrefKeys.EMAIL_VERIFIED);
   }
+
+  private async setPoints(value: number) {
+    return this.preferences.setNumber(PrefKeys.POINTS, value);
+  }
+
+  async getPoints() {
+    return this.preferences.getNumber(PrefKeys.POINTS);
+  }
 }
 
 const enum PrefKeys {
@@ -345,6 +356,7 @@ const enum PrefKeys {
   EMAIL = 'EMAIL',
   EMAIL_VERIFIED = 'EMAIL_VERIFIED',
   PHONE_VERIFIED = 'PHONE_VERIFIED',
+  POINTS = 'POINTS',
 }
 
 interface LoginResult {
@@ -361,6 +373,15 @@ export interface ReadUserResponse {
   readonly email: string;
   readonly phone_verified: boolean;
   readonly email_verified: boolean;
+  readonly user_wallet: {
+    asset_wallet: string;
+    asset_wallet_num: string | null;
+    integrity_wallet: string;
+    integrity_wallet_num: string | null;
+    points: string;
+    num_wallet_name: string;
+    billed_num: string;
+  };
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
- Support points system and connect it to the backend
- Hide buy NUM button

## Test Plan
<img width="429" alt="image" src="https://user-images.githubusercontent.com/35753861/158532773-117f76ae-016b-4e46-8922-b3c702a858f7.png">



```bash
➜  capture-lite git:(feature-support-points-hide-buy-num) ✗ npm run test.ci                                                   

> capture-lite@0.50.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.50.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

16 03 2022 14:44:56.097:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
16 03 2022 14:44:56.098:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
16 03 2022 14:44:56.100:INFO [launcher]: Starting browser ChromeHeadless
16 03 2022 14:45:02.673:INFO [Chrome Headless 99.0.4844.51 (Mac OS 10.15.7)]: Connected on socket r8Zl4IPb8cb8YMVTAAAB with id 55615128
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 6 of 219 SUCCESS (0 secs / 0.08 secs)
ERROR: HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/action', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/action: 404 Not Found', error: 'NOT FOUND'}
ERROR: 'NG0304: 'app-network-action-orders' is not a known element:
1. If 'app-network-action-orders' is an Angular component, then verify that it is part of this module.
2. If 'app-network-action-orders' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 218 of 219 (2 FAILED) (0 secs / 28.712 secs)
16 03 2022 14:45:32.051:WARN [web-server]: 404: /_karma_webpack_/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%
ERROR: 'ERROR', HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true: 404 Not Found', error: 'NOT FOUND'}
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 219 of 219 (2 FAILED) (28.932 secs / 28.722 secs)
TOTAL: 2 FAILED, 217 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.25% ( 1829/3569 )
Branches     : 29.15% ( 297/1019 )
Functions    : 40.23% ( 636/1581 )
Lines        : 53.08% ( 1654/3116 )
================================================================================
➜  capture-lite git:(feature-support-points-hide-buy-num) ✗
```