### PR TITLE
Fix network action order history generated even when confirm order failed

### DIFF
--- a/src/app/features/home/details/actions/actions.page.ts
+++ b/src/app/features/home/details/actions/actions.page.ts
@@ -126,7 +126,6 @@ export class ActionsPage {
   }
 
   doAction(action: Action) {
-    let networkAppOrder: NetworkAppOrder;
     this.openActionDialog$(action)
       .pipe(
         concatMap(createOrderInput =>
@@ -137,13 +136,12 @@ export class ActionsPage {
             )
           )
         ),
-        concatMap(orderStatus => {
-          networkAppOrder = orderStatus;
-          return this.openOrderDialog$(orderStatus);
-        }),
-        tap(() => this.createOrderHistory$(networkAppOrder).subscribe()),
+        concatMap(orderStatus => this.openOrderDialog$(orderStatus)),
         concatMap(orderId =>
           this.blockingActionService.run$(this.confirmOrder$(orderId))
+        ),
+        tap(networkAppOrder =>
+          this.createOrderHistory$(networkAppOrder).subscribe()
         ),
         tap(() => {
           this.snackBar.open(


### PR DESCRIPTION
Fix network action order history generated even when confirm order failed

## Test Plan
Before: https://youtu.be/yGyEsLqA75Q
After: https://youtu.be/nV6KU0MOnBk
```bash
➜  capture-lite git:(fix-network-action-order-history-generated-even-when-confirm-order-failed) npm run test.ci

> capture-lite@0.50.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.50.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

16 03 2022 16:09:51.970:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
16 03 2022 16:09:51.971:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
16 03 2022 16:09:51.973:INFO [launcher]: Starting browser ChromeHeadless
16 03 2022 16:09:58.458:INFO [Chrome Headless 99.0.4844.51 (Mac OS 10.15.7)]: Connected on socket 2RW1QhL5Bb8vWM8QAAAB with id 68174365
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 2 of 219 SUCCESS (0 secs / 0.074 secs)
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 13 of 219 SUCCESS (0 secs / 0.157 secs)
16 03 2022 16:09:59.098:WARN [web-server]: 404: /_karma_webpack_/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22c
ERROR: 'ERROR', HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true: 404 Not Found', error: 'NOT FOUND'}
ERROR: 'NG0304: 'app-network-action-orders' is not a known element:
1. If 'app-network-action-orders' is an Angular component, then verify that it is part of this module.
2. If 'app-network-action-orders' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/action', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/action: 404 Not Found', error: 'NOT FOUND'}
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.51 (Mac OS 10.15.7): Executed 219 of 219 (1 FAILED) (26.631 secs / 26.42 secs)
TOTAL: 1 FAILED, 218 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.1% ( 1817/3556 )
Branches     : 29.08% ( 296/1018 )
Functions    : 40.18% ( 632/1573 )
Lines        : 53.02% ( 1642/3097 )
================================================================================
➜  capture-lite git:(fix-network-action-order-history-generated-even-when-confirm-order-failed)
```