### PR TITLE
fix(network-action-orders.component.ts): add catchError to networkAct…

### DIFF
--- a/src/app/features/home/activities/network-action-orders/network-action-orders.component.ts
+++ b/src/app/features/home/activities/network-action-orders/network-action-orders.component.ts
@@ -2,13 +2,14 @@ import { Component } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { combineLatest, EMPTY } from 'rxjs';
-import { first, map, pluck } from 'rxjs/operators';
+import { catchError, first, map, pluck } from 'rxjs/operators';
 import {
   ActionsService,
   BubbleOrderHistoryRecord,
 } from '../../../../shared/actions/service/actions.service';
 import { DiaBackendAssetRepository } from '../../../../shared/dia-backend/asset/dia-backend-asset-repository.service';
 import { DiaBackendTransactionRepository } from '../../../../shared/dia-backend/transaction/dia-backend-transaction-repository.service';
+import { ErrorService } from '../../../../shared/error/error.service';
 import { Proof } from '../../../../shared/repositories/proof/proof';
 import { ProofRepository } from '../../../../shared/repositories/proof/proof-repository.service';
 @UntilDestroy({ checkProperties: true })
@@ -29,6 +30,7 @@ export class NetworkActionOrdersComponent {
       });
       return orders;
     }),
+    catchError((err: unknown) => this.errorService.toastError$(err)),
     untilDestroyed(this)
   );
 
@@ -37,7 +39,8 @@ export class NetworkActionOrdersComponent {
     private readonly actionsService: ActionsService,
     private readonly sanitizer: DomSanitizer,
     private readonly diaBackendTransactionRepository: DiaBackendTransactionRepository,
-    private readonly diaBackendAssetRepository: DiaBackendAssetRepository
+    private readonly diaBackendAssetRepository: DiaBackendAssetRepository,
+    private readonly errorService: ErrorService
   ) {}
 
   fetchThumbnailUrl$(proofs: Proof[], order: BubbleOrderHistoryRecord) {


### PR DESCRIPTION
Add catchError to networkActionOrders$ so that error could be displayed if there's any.


## Test Plan
<img width="390" alt="image" src="https://user-images.githubusercontent.com/35753861/159205761-14150119-b0bb-42ec-86cd-d6f408878e94.png">

```bash
➜  capture-lite git:(fix-error-display-on-network-action-order-history-page) npm run test.ci

> capture-lite@0.50.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.50.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

21 03 2022 12:33:47.667:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
21 03 2022 12:33:47.668:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
21 03 2022 12:33:47.671:INFO [launcher]: Starting browser ChromeHeadless
21 03 2022 12:33:54.207:INFO [Chrome Headless 99.0.4844.74 (Mac OS 10.15.7)]: Connected on socket zrUhnWiQtA4jlo2KAAAB with id 99360463
Chrome Headless 99.0.4844.74 (Mac OS 10.15.7): Executed 0 of 219 SUCCESS (0 secs / 0 secs)
21 03 2022 12:33:54.737:WARN [web-server]: 404: /_karma_webpack_/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22c
ERROR: HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true: 404 Not Found', error: 'NOT FOUND'}
ERROR: '<ion-refresher> must be used inside an <ion-content>'
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.74 (Mac OS 10.15.7): Executed 168 of 219 SUCCESS (0 secs / 7.557 secs)
ERROR: HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/action', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/action: 404 Not Found', error: 'NOT FOUND'}
Chrome Headless 99.0.4844.74 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.74 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
Chrome Headless 99.0.4844.74 (Mac OS 10.15.7): Executed 219 of 219 (2 FAILED) (26.679 secs / 26.482 secs)
TOTAL: 2 FAILED, 217 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.26% ( 1829/3568 )
Branches     : 29.27% ( 298/1018 )
Functions    : 40.29% ( 637/1581 )
Lines        : 53.17% ( 1654/3111 )
================================================================================
➜  capture-lite git:(fix-error-display-on-network-action-order-history-page)
```
