### PR TITLE
fix: fix ios activity details page cid overflow

### DIFF
--- a/src/app/features/home/activities/capture-transaction-details/capture-transaction-details.page.html
+++ b/src/app/features/home/activities/capture-transaction-details/capture-transaction-details.page.html
@@ -9,7 +9,7 @@
     {{ (transaction$ | ngrxPush)?.created_at | date: 'short' }}
   </h4>
   <mat-card class="transaction-card">
-    <mat-card-content class="row">
+    <mat-card-content class="row wrap-text">
       <mat-label>
         {{ t('digitalAsset') }} ID:
         {{ (transaction$ | ngrxPush)?.asset?.id }}
@@ -20,7 +20,7 @@
       loading="lazy"
       [src]="(transaction$ | ngrxPush)?.asset?.asset_file_thumbnail"
     />
-    <mat-card-content class="column">
+    <mat-card-content class="column wrap-text">
       <mat-label>
         {{ t('sentFrom') }}: {{ (transaction$ | ngrxPush)?.sender_name }}
       </mat-label>

--- a/src/app/features/home/activities/capture-transaction-details/capture-transaction-details.page.scss
+++ b/src/app/features/home/activities/capture-transaction-details/capture-transaction-details.page.scss
@@ -76,19 +76,10 @@ mat-card img {
   margin: 10% 25%;
 }
 
-form mat-form-field {
-  width: 100%;
-  height: 100%;
-
-  textarea {
-    overflow: hidden;
-  }
-}
-
-.spacer {
-  flex: 1 1 auto;
+.wrap-text {
+  overflow-wrap: anywhere;
 }
 
 mat-label {
-  overflow-wrap: anywhere;
+  max-width: 90%;
 }


### PR DESCRIPTION
Fix ios activity details page cid overflow. I add `max-width: 90%;` to `mat-label` so now it should never overflow.

## Test Plan
Screenshot from my iPhone:
![IMG!UNITO-UNDERSCORE!1A4AEA20B23F-1](https://user-images.githubusercontent.com/35753861/159268884-c727fe16-95e9-4a52-80d7-aa3818075c06.jpeg)

```bash
➜  capture-lite git:(fix-ios-activity-details-cid-overflow) ✗ npm run test.ci

> capture-lite@0.50.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.50.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

21 03 2022 21:15:36.571:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
21 03 2022 21:15:36.573:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
21 03 2022 21:15:36.575:INFO [launcher]: Starting browser ChromeHeadless
21 03 2022 21:15:43.650:INFO [Chrome Headless 99.0.4844.74 (Mac OS 10.15.7)]: Connected on socket t0ODypApFj_A-IQqAAAB with id 34224168
Chrome Headless 99.0.4844.74 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: '<ion-refresher> must be used inside an <ion-content>'
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.74 (Mac OS 10.15.7): Executed 219 of 219 (1 FAILED) (27.178 secs / 26.977 secs)
TOTAL: 1 FAILED, 218 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.12% ( 1824/3568 )
Branches     : 28.98% ( 295/1018 )
Functions    : 40.16% ( 635/1581 )
Lines        : 53.07% ( 1651/3111 )
================================================================================
➜  capture-lite git:(fix-ios-activity-details-cid-overflow) ✗
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1202001304057541) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
