### PR TITLE
fix: rename more actions to network actions

### DIFF
--- a/src/app/features/home/activities/activities.page.html
+++ b/src/app/features/home/activities/activities.page.html
@@ -11,7 +11,7 @@
       <ion-label>{{ t('captureTransactions') }}</ion-label>
     </ion-segment-button>
     <ion-segment-button value="networkActionOrders">
-      <ion-label>{{ t('message.moreActions') }}</ion-label>
+      <ion-label>{{ t('networkActions') }}</ion-label>
     </ion-segment-button>
   </ion-segment>
 

--- a/src/app/features/home/details/actions/actions.page.html
+++ b/src/app/features/home/details/actions/actions.page.html
@@ -2,7 +2,7 @@
   <button routerLink=".." routerDirection="back" mat-icon-button>
     <mat-icon>arrow_back</mat-icon>
   </button>
-  <span>{{ t('message.moreActions') }}</span>
+  <span>{{ t('networkActions') }}</span>
 </mat-toolbar>
 
 <div class="page-content">

--- a/src/app/features/home/details/details.page.ts
+++ b/src/app/features/home/details/details.page.ts
@@ -311,7 +311,7 @@ export class DetailsPage {
         'message.mintNftToken': null,
         'message.viewBlockchainCertificate': null,
         'message.viewSupportingVideoOnIpfs': null,
-        'message.moreActions': null,
+        networkActions: null,
       }),
     ])
       .pipe(
@@ -328,7 +328,7 @@ export class DetailsPage {
               messageMintNftToken,
               messageViewBlockchainCertificate,
               messageViewSupportingVideoOnIpfs,
-              messageMoreActions,
+              messageNetworkActions,
             ],
           ]) =>
             new Promise<void>(resolve => {
@@ -390,7 +390,7 @@ export class DetailsPage {
               }
               if (postCreationWorkflowCompleted) {
                 buttons.push({
-                  text: messageMoreActions,
+                  text: messageNetworkActions,
                   handler: () => {
                     this.router.navigate(
                       ['actions', { id: detailedCapture.id }],

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -99,7 +99,7 @@
   "resendIn": "Re-send {{ secondsRemained }}s",
   "balance": "Balance",
   "walletAddress": "Wallet Address",
-
+  "networkActions": "Network Actions",
   "yourPrivateKey": "Your Private Key",
   "copyToClipboard": "Copy To Clipboard",
   "verification": {
@@ -175,7 +175,6 @@
     "shareC2paPhoto": "Share C2PA photo",
     "mintNftToken": "Mint NFT token",
     "mintNftAlert": "Once the NFT is minted, photo and its information can be accessed publicly. Do you still want to proceed?",
-    "moreActions": "More Actions",
     "sentSuccessfully": "Sent Successfully",
     "confirmCopyPrivateKey": "Warning: Please do not expose your private key to anyone. Lost of private key may cause your account to be lost permanently."
   },

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -99,7 +99,7 @@
   "resendIn": "重新發送 {{ secondsRemained }}秒",
   "balance": "餘額",
   "walletAddress": "錢包地址",
-
+  "networkActions": "網絡動作",
   "yourPrivateKey": "您的私鑰",
   "copyToClipboard": "複製到剪貼簿",
   "verification": {
@@ -175,7 +175,6 @@
     "shareC2paPhoto": "分享 C2PA 照片",
     "mintNftToken": "鑄造 NFT 代幣",
     "mintNftAlert": "NFT 代幣鑄造後，影像以及所有資訊都將可被公開檢視。確定要繼續嗎？",
-    "moreActions": "更多動作",
     "sentSuccessfully": "成功送出",
     "confirmCopyPrivateKey": "警告：請不要向任何人揭露您的金鑰，未保管好金鑰可能導致您永遠失去您的帳號。"
   },


### PR DESCRIPTION
Rename more actions to network actions.

## Test Plan
![](https://user-images.githubusercontent.com/35753861/159278916-75877305-a3fe-4c94-91f2-04ff508e2c60.png)

![](https://user-images.githubusercontent.com/35753861/159278993-7dd2727d-9440-4547-93da-689ad6a141db.png)

```bash
➜  capture-lite git:(fix-rename-more-actions-to-network-actions) ✗ npm run test.ci

> capture-lite@0.50.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.50.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

21 03 2022 22:09:20.800:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
21 03 2022 22:09:20.801:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
21 03 2022 22:09:20.803:INFO [launcher]: Starting browser ChromeHeadless
21 03 2022 22:09:27.463:INFO [Chrome Headless 99.0.4844.74 (Mac OS 10.15.7)]: Connected on socket pdCJntRc5A3iV4DhAAAB with id 57097020
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.74 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
Chrome Headless 99.0.4844.74 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.74 (Mac OS 10.15.7): Executed 219 of 219 (2 FAILED) (30.592 secs / 30.371 secs)
TOTAL: 2 FAILED, 217 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.29% ( 1830/3568 )
Branches     : 29.27% ( 298/1018 )
Functions    : 40.35% ( 638/1581 )
Lines        : 53.23% ( 1656/3111 )
================================================================================
➜  capture-lite git:(fix-rename-more-actions-to-network-actions) ✗
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1202001305551615) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
