### PR TITLE
fix(actions.page.ts): only create a order history record if the total…

### DIFF
--- a/src/app/features/home/details/actions/actions.page.ts
+++ b/src/app/features/home/details/actions/actions.page.ts
@@ -142,9 +142,11 @@ export class ActionsPage {
         concatMap(orderId =>
           this.blockingActionService.run$(this.confirmOrder$(orderId))
         ),
-        tap(networkAppOrder =>
-          this.createOrderHistory$(networkAppOrder).subscribe()
-        ),
+        tap(networkAppOrder => {
+          if (Number(networkAppOrder.total_cost) !== 0) {
+            this.createOrderHistory$(networkAppOrder).subscribe();
+          }
+        }),
         tap(() => {
           this.snackBar.open(
             this.translocoService.translate('message.sentSuccessfully')

--- a/src/app/features/home/details/actions/actions.page.ts
+++ b/src/app/features/home/details/actions/actions.page.ts
@@ -143,6 +143,14 @@ export class ActionsPage {
           this.blockingActionService.run$(this.confirmOrder$(orderId))
         ),
         tap(networkAppOrder => {
+          /*
+            Workaround:
+            Create a order history record only if the total cost is > 0 to prevent race condition 
+            between app creating the order history record v.s. bubble workflow checking whether a 
+            record already exists and if not create a new one, especially for network actions that 
+            don't require any cost (and hence backend calls the webhook immediately). See 
+            https://dt42-numbers.slack.com/archives/C0323488MEJ/p1648006014291339
+          */
           if (Number(networkAppOrder.total_cost) !== 0) {
             this.createOrderHistory$(networkAppOrder).subscribe();
           }


### PR DESCRIPTION
Only create a order history record if the total cost is > 0 to prevent race condition between app creating the order history record v.s. bubble workflow checking whether a record already exist and if not create a new one. See https://dt42-numbers.slack.com/archives/C0323488MEJ/p1648006014291339

## Test Plan

```bash
➜  capture-lite git:(fix-order-history-creation-race-condition) ✗ npm run test.ci

> capture-lite@0.50.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.50.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

23 03 2022 11:51:56.211:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
23 03 2022 11:51:56.212:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
23 03 2022 11:51:56.213:INFO [launcher]: Starting browser ChromeHeadless
23 03 2022 11:52:02.825:INFO [Chrome Headless 99.0.4844.83 (Mac OS 10.15.7)]: Connected on socket sTmmScLVSBsP0vXkAAAB with id 67522674
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3793:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3793:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3793:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should read thumbnail FAILED
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3793:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3793:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
        Error: Expected false to be true.
            at <Jasmine>
            at http://localhost:9876/_karma_webpack_/main.js:3793:47
            at Generator.next (<anonymous>)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342838:58)
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7): Executed 221 of 221 (3 FAILED) (29.067 secs / 28.854 secs)
TOTAL: 3 FAILED, 218 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.5% ( 1855/3602 )
Branches     : 29.16% ( 298/1022 )
Functions    : 40.5% ( 646/1595 )
Lines        : 53.45% ( 1679/3141 )
================================================================================
➜  capture-lite git:(fix-order-history-creation-race-condition) ✗ 
```