### PR TITLE
fix: prevent user from performing List in CaptureClub with the same a…

### DIFF
--- a/src/app/shared/dia-backend/store/dia-backend-store.service.ts
+++ b/src/app/shared/dia-backend/store/dia-backend-store.service.ts
@@ -1,8 +1,9 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { defer } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
 import { DiaBackendAuthService } from '../auth/dia-backend-auth.service';
+import { PaginatedResponse } from '../pagination';
 import { BASE_URL } from '../secret';
 
 @Injectable({
@@ -41,11 +42,25 @@ export class DiaBackendStoreService {
       })
     );
   }
+
+  listAllProducts$(
+    queryParams: { associated_id?: string; service_name?: string } = {}
+  ) {
+    return defer(() => this.authService.getAuthHeadersWithApiKey()).pipe(
+      concatMap(headers => {
+        const params = new HttpParams({ fromObject: queryParams });
+        return this.httpClient.get<PaginatedResponse<Product>>(
+          `${BASE_URL}/api/v3/store/products/`,
+          { headers, params }
+        );
+      })
+    );
+  }
 }
 
 export interface NetworkAppOrder {
   id: string;
-  status: 'completed' | 'canceled' | 'pending';
+  status: 'created' | 'success' | 'failure' | 'pending';
   network_app_id: string;
   network_app_name: string;
   action: string;
@@ -62,4 +77,33 @@ export interface NetworkAppOrder {
   owner: string;
   created_at: string;
   expired_at: string;
+}
+
+export interface Product {
+  id: string;
+  associated_id: string;
+  type: string;
+  service_name: string;
+  subject: string;
+  description: string;
+  tags: string[];
+  cover_image: string;
+  cover_image_thumbnail: string;
+  product_url: string;
+  external_product_url: string;
+  price: string;
+  price_base: 'usd' | 'num';
+  quantity: number;
+  in_stock: number;
+  nft_token_id: number;
+  nft_token_uri: string;
+  nft_blockchain_name: string;
+  nft_contract_address: string;
+  owner: string;
+  owner_name: string;
+  original_creator: string;
+  original_creator_name: string;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
 }

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -182,7 +182,8 @@
     "mintNftToken": "Mint NFT token",
     "mintNftAlert": "Once the NFT is minted, photo and its information can be accessed publicly. Do you still want to proceed?",
     "sentSuccessfully": "Sent Successfully",
-    "confirmCopyPrivateKey": "Warning: Please do not expose your private key to anyone. Lost of private key may cause your account to be lost permanently."
+    "confirmCopyPrivateKey": "Warning: Please do not expose your private key to anyone. Lost of private key may cause your account to be lost permanently.",
+    "hasListedInCaptureClub": "This asset has already been listed in CaptureClub."
   },
   "error": {
     "validationError": "Invalid operation. Please check your input again.",

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -182,7 +182,8 @@
     "mintNftToken": "鑄造 NFT 代幣",
     "mintNftAlert": "NFT 代幣鑄造後，影像以及所有資訊都將可被公開檢視。確定要繼續嗎？",
     "sentSuccessfully": "成功送出",
-    "confirmCopyPrivateKey": "警告：請不要向任何人揭露您的金鑰，未保管好金鑰可能導致您永遠失去您的帳號。"
+    "confirmCopyPrivateKey": "警告：請不要向任何人揭露您的金鑰，未保管好金鑰可能導致您永遠失去您的帳號。",
+    "hasListedInCaptureClub": "該資產已在 CaptureClub 上架。"
   },
   "error": {
     "validationError": "操作或輸入有誤，請確認您的操作正確。",


### PR DESCRIPTION
Prevent user from performing List in CaptureClub with the same asset twice. I check whether an asset has been listed on CaptureClub based on the discussion [here](https://app.asana.com/0/0/1201558520076805/1201995911008176/f).

## Test Plan
Demo Video: https://youtu.be/48YA0Gee9Co

```bash
➜  capture-lite git:(feature-let-user-know-if-capture-is-listed-on-CC) ✗ npm run test.ci

> capture-lite@0.50.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.50.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

23 03 2022 13:26:55.326:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
23 03 2022 13:26:55.327:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
23 03 2022 13:26:55.330:INFO [launcher]: Starting browser ChromeHeadless
23 03 2022 13:27:01.963:INFO [Chrome Headless 99.0.4844.83 (Mac OS 10.15.7)]: Connected on socket YM85j2aLm8QrQX25AAAB with id 55761372
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: TypeError: config.get is not a function
TypeError: config.get is not a function
    at removeEventListener (http://localhost:9876/_karma_webpack_/vendor.js:178721:26)
    at SegmentButton.disconnectedCallback (http://localhost:9876/_karma_webpack_/node_modules_ionic_core_dist_esm_ion-segment_2_entry_js.js:484:62)
    at safeCall (http://localhost:9876/_karma_webpack_/vendor.js:180876:30)
    at disconnectedCallback (http://localhost:9876/_karma_webpack_/vendor.js:181560:7)
    at http://localhost:9876/_karma_webpack_/vendor.js:181666:23
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
    at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
    at NgZone.runOutsideAngular (http://localhost:9876/_karma_webpack_/vendor.js:92373:28), undefined
ERROR: TypeError: config.get is not a function
TypeError: config.get is not a function
    at removeEventListener (http://localhost:9876/_karma_webpack_/vendor.js:178721:26)
    at SegmentButton.disconnectedCallback (http://localhost:9876/_karma_webpack_/node_modules_ionic_core_dist_esm_ion-segment_2_entry_js.js:484:62)
    at safeCall (http://localhost:9876/_karma_webpack_/vendor.js:180876:30)
    at disconnectedCallback (http://localhost:9876/_karma_webpack_/vendor.js:181560:7)
    at http://localhost:9876/_karma_webpack_/vendor.js:181666:23
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
    at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
    at NgZone.runOutsideAngular (http://localhost:9876/_karma_webpack_/vendor.js:92373:28), undefined
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7): Executed 221 of 221 (2 FAILED) (31.117 secs / 30.867 secs)
TOTAL: 2 FAILED, 219 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.2% ( 1857/3627 )
Branches     : 28.95% ( 297/1026 )
Functions    : 40.17% ( 646/1608 )
Lines        : 53.21% ( 1681/3159 )
================================================================================
➜  capture-lite git:(feature-let-user-know-if-capture-is-listed-on-CC) ✗ 
```