### PR TITLE
feat: warn user that the asset will become public when share asset pr…

### DIFF
--- a/src/app/features/home/details/details.page.ts
+++ b/src/app/features/home/details/details.page.ts
@@ -265,7 +265,7 @@ export class DetailsPage {
         concatMap(
           ([
             diaBackendAsset,
-            [messageCopyIpfsAddress, messageShareC2paPhoto],
+            [messageCopyIpfsAddress, messageShareAssetProfile],
           ]) =>
             new Promise<void>(resolve => {
               const buttons: ActionSheetButton[] = [];
@@ -281,9 +281,17 @@ export class DetailsPage {
               }
               if (diaBackendAsset?.cai_file) {
                 buttons.push({
-                  text: messageShareC2paPhoto,
-                  handler: () => {
-                    this.share();
+                  text: messageShareAssetProfile,
+                  handler: async () => {
+                    const result = await this.confirmAlert.present({
+                      message:
+                        this.translocoService.translate(
+                          'message.assetBecomePublicAfterSharing'
+                        ) + '!',
+                    });
+                    if (result) {
+                      this.share();
+                    }
                     resolve();
                   },
                 });

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -179,6 +179,7 @@
     "verificationSuccess": "Success",
     "copyIpfsAddress": "Copy IPFS address",
     "shareAssetProfile": "Share Asset Profile",
+    "assetBecomePublicAfterSharing": "This asset will become public after sharing",
     "mintNftToken": "Mint NFT token",
     "mintNftAlert": "Once the NFT is minted, photo and its information can be accessed publicly. Do you still want to proceed?",
     "sentSuccessfully": "Sent Successfully",

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -179,6 +179,7 @@
     "verificationSuccess": "驗證成功",
     "copyIpfsAddress": "複製 IPFS 位址",
     "shareAssetProfile": "分享資產檔案",
+    "assetBecomePublicAfterSharing": "該資產將在分享後公開",
     "mintNftToken": "鑄造 NFT 代幣",
     "mintNftAlert": "NFT 代幣鑄造後，影像以及所有資訊都將可被公開檢視。確定要繼續嗎？",
     "sentSuccessfully": "成功送出",


### PR DESCRIPTION
Warn user that the asset will become public when share asset profile. See https://github.com/numbersprotocol/capture-lite/issues/1419

## Test Plan
<img width="458" alt="image" src="https://user-images.githubusercontent.com/35753861/160318819-88483655-9498-4194-9a5c-a3b506ca9c7d.png">

```bash
➜  capture-lite git:(feature-warn-user-when-share-asset-profile) ✗ npm run test.ci

> capture-lite@0.52.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.52.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

28 03 2022 10:53:28.287:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
28 03 2022 10:53:28.295:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
28 03 2022 10:53:28.304:INFO [launcher]: Starting browser ChromeHeadless
28 03 2022 10:53:36.182:INFO [Chrome Headless 99.0.4844.83 (Mac OS 10.15.7)]: Connected on socket _WK6XyjDWZghGLLgAAAB with id 60190192
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7): Executed 16 of 221 SUCCESS (0 secs / 0.21 secs)
28 03 2022 10:53:36.862:WARN [web-server]: 404: /_karma_webpack_/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%2
ERROR: HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/order?constraints=%5B%7B%22key%22:%20%22uid%22,%20%22constraint_type%22:%20%22equals%22,%20%22value%22:%20%22%22%20%7D%20%5D&sort_field=Created%20Date&descending=true: 404 Not Found', error: 'NOT FOUND'}
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7): Executed 96 of 221 SUCCESS (0 secs / 0.61 secs)
ERROR: TypeError: config.get is not a function
TypeError: config.get is not a function
    at removeEventListener (http://localhost:9876/_karma_webpack_/vendor.js:178721:26)
    at SegmentButton.disconnectedCallback (http://localhost:9876/_karma_webpack_/node_modules_ionic_core_dist_esm_ion-segment_2_entry_js.js:484:62)
    at safeCall (http://localhost:9876/_karma_webpack_/vendor.js:180876:30)
    at disconnectedCallback (http://localhost:9876/_karma_webpack_/vendor.js:181560:7)
    at http://localhost:9876/_karma_webpack_/vendor.js:181666:23
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
    at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
    at NgZone.runOutsideAngular (http://localhost:9876/_karma_webpack_/vendor.js:92373:28), undefined
ERROR: TypeError: config.get is not a function
TypeError: config.get is not a function
    at removeEventListener (http://localhost:9876/_karma_webpack_/vendor.js:178721:26)
    at SegmentButton.disconnectedCallback (http://localhost:9876/_karma_webpack_/node_modules_ionic_core_dist_esm_ion-segment_2_entry_js.js:484:62)
    at safeCall (http://localhost:9876/_karma_webpack_/vendor.js:180876:30)
    at disconnectedCallback (http://localhost:9876/_karma_webpack_/vendor.js:181560:7)
    at http://localhost:9876/_karma_webpack_/vendor.js:181666:23
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
    at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
    at NgZone.runOutsideAngular (http://localhost:9876/_karma_webpack_/vendor.js:92373:28), undefined
ERROR: HttpErrorResponse{headers: HttpHeaders{normalizedNames: Map{}, lazyUpdate: null, lazyInit: () => { ... }}, status: 404, statusText: 'Not Found', url: 'http://localhost:9876/undefined/api/1.1/obj/action', ok: false, name: 'HttpErrorResponse', message: 'Http failure response for http://localhost:9876/undefined/api/1.1/obj/action: 404 Not Found', error: 'NOT FOUND'}
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7): Executed 221 of 221 (2 FAILED) (26.248 secs / 26.037 secs)
TOTAL: 2 FAILED, 219 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.09% ( 1853/3627 )
Branches     : 28.78% ( 297/1032 )
Functions    : 40.1% ( 644/1606 )
Lines        : 52.97% ( 1675/3162 )
================================================================================
➜  capture-lite git:(feature-warn-user-when-share-asset-profile) ✗
```