### PR TITLE
feat: add loading indicator at capture transactions history page

### DIFF
--- a/src/app/features/home/activities/capture-transactions/capture-transactions.component.html
+++ b/src/app/features/home/activities/capture-transactions/capture-transactions.component.html
@@ -1,3 +1,5 @@
+<mat-spinner diameter="30" *ngIf="isFetching$ | ngrxPush"></mat-spinner>
+
 <div *transloco="let t">
   <mat-list *ngrxLet="transactionsWithStatus$ as transactions">
     <h5 id="empty-transaction-msg" *ngIf="transactions.length === 0">

--- a/src/app/features/home/activities/capture-transactions/capture-transactions.component.scss
+++ b/src/app/features/home/activities/capture-transactions/capture-transactions.component.scss
@@ -1,3 +1,10 @@
+mat-spinner {
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 10%;
+  width: 100%;
+}
+
 #empty-transaction-msg {
   text-align: center;
   color: gray;


### PR DESCRIPTION
Add loading indicator at capture transactions history page.

## Future work: 
Maybe we could cache this locally and pull from backend only when user pull to refresh. Same for network action orders history.

## Test Plan
```bash
➜  capture-lite git:(feature-add-loading-indicator-at-capture-transactions-page) ✗ npm run test.ci

> capture-lite@0.52.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.52.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

28 03 2022 12:01:23.998:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
28 03 2022 12:01:23.998:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
28 03 2022 12:01:24.000:INFO [launcher]: Starting browser ChromeHeadless
28 03 2022 12:01:31.003:INFO [Chrome Headless 99.0.4844.83 (Mac OS 10.15.7)]: Connected on socket zmnLVocs9BzlOEpKAAAB with id 25668539
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7): Executed 221 of 221 (2 FAILED) (28.146 secs / 27.908 secs)
TOTAL: 2 FAILED, 219 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.19% ( 1856/3626 )
Branches     : 28.93% ( 298/1030 )
Functions    : 40.29% ( 647/1606 )
Lines        : 53.13% ( 1680/3162 )
================================================================================
➜  capture-lite git:(feature-add-loading-indicator-at-capture-transactions-page) ✗
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1202031733290719) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
