### PR TITLE
feat: support optional network action parameters

### DIFF
--- a/src/app/shared/actions/actions-dialog/actions-dialog.component.ts
+++ b/src/app/shared/actions/actions-dialog/actions-dialog.component.ts
@@ -38,6 +38,8 @@ export class ActionsDialogComponent {
 
   private createFormFields() {
     for (const param of this.params) {
+      const isOptional = param.optional_boolean ?? false;
+
       if (param.type_text === 'dropdown')
         this.fields.push({
           key: param.name_text,
@@ -49,7 +51,7 @@ export class ActionsDialogComponent {
             })),
             placeholder: param.placeholder_text,
             disabled: !param.user_input_boolean,
-            required: true,
+            required: !isOptional,
           },
         });
       else if (param.type_text === 'number')
@@ -63,7 +65,7 @@ export class ActionsDialogComponent {
             disabled: !param.user_input_boolean,
             max: param.max_number,
             min: param.min_number,
-            required: true,
+            required: !isOptional,
           },
         });
       else
@@ -75,7 +77,7 @@ export class ActionsDialogComponent {
             label: param.display_text_text,
             placeholder: param.placeholder_text,
             disabled: !param.user_input_boolean,
-            required: true,
+            required: !isOptional,
           },
         });
     }

--- a/src/app/shared/actions/service/actions.service.ts
+++ b/src/app/shared/actions/service/actions.service.ts
@@ -55,6 +55,7 @@ export interface Param {
   readonly user_input_boolean: boolean;
   readonly max_number: number;
   readonly min_number: number;
+  readonly optional_boolean?: boolean;
 }
 
 export interface GetActionsResponse<T> {


### PR DESCRIPTION
Support optional network action parameters.

## Test Plan
### Before:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/35753861/160339345-9c6a22dc-fac9-4e27-825c-a31addc7b3f1.png">

### After:
Notice that user can proceed without entering the remaining 2 fields.
<img width="391" alt="image" src="https://user-images.githubusercontent.com/35753861/160339268-31e0901a-4fe7-41a7-959f-e8fcf6782c20.png">


```bash
➜  capture-lite git:(feature-support-optional-network-action-params) npm run test.ci

> capture-lite@0.52.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.52.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

28 03 2022 14:29:01.263:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
28 03 2022 14:29:01.264:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
28 03 2022 14:29:01.265:INFO [launcher]: Starting browser ChromeHeadless
28 03 2022 14:29:08.198:INFO [Chrome Headless 99.0.4844.83 (Mac OS 10.15.7)]: Connected on socket owAM_K8XZTwqipWBAAAB with id 62827311
ERROR: '<ion-refresher> must be used inside an <ion-content>'
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:154115:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7): Executed 221 of 221 (1 FAILED) (26.316 secs / 26.095 secs)
TOTAL: 1 FAILED, 220 SUCCESS

=============================== Coverage summary ===============================
Statements   : 51.01% ( 1849/3625 )
Branches     : 28.43% ( 294/1034 )
Functions    : 40.06% ( 643/1605 )
Lines        : 52.97% ( 1674/3160 )
================================================================================
➜  capture-lite git:(feature-support-optional-network-action-params) 
```