### PR TITLE
feat: support 0 parameter network action

### DIFF
--- a/src/app/features/home/details/actions/actions.page.ts
+++ b/src/app/features/home/details/actions/actions.page.ts
@@ -119,7 +119,7 @@ export class ActionsPage {
 
   openActionDialog$(action: Action) {
     return combineLatest([
-      this.actionsService.getParams$(action.params_list_custom_param1),
+      this.actionsService.getParams$(action.params_list_custom_param1 ?? []),
       this.authService.token$,
       this.id$,
     ]).pipe(

--- a/src/app/shared/actions/service/actions.service.ts
+++ b/src/app/shared/actions/service/actions.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { defer, forkJoin } from 'rxjs';
+import { defer, forkJoin, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { BUBBLE_DB_URL } from '../../dia-backend/secret';
 
@@ -19,6 +19,7 @@ export class ActionsService {
   }
 
   getParams$(ids: string[]) {
+    if (ids.length === 0) return of([]);
     return defer(() =>
       forkJoin(
         ids.map(id =>
@@ -40,7 +41,7 @@ export interface Action {
   readonly banner_image_url_text: string;
   readonly base_url_text: string;
   readonly description_text: string;
-  readonly params_list_custom_param1: string[];
+  readonly params_list_custom_param1?: string[];
   readonly title_text: string;
   readonly network_app_id_text: string;
 }


### PR DESCRIPTION
Support 0 parameter network action. Previously the app would throw error if a network action does not have any parameters.

## Test Plan
Demo:
<img width="394" alt="image" src="https://user-images.githubusercontent.com/35753861/160611318-39ed55f2-9328-4f4d-a716-b5d952b80676.png">


```bash
➜  capture-lite git:(feature-support-0-parameter-network-action) npm run test.ci

> capture-lite@0.52.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.52.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

Compiling @angular/core/testing : es2015 as esm2015
Compiling @angular/platform-browser/testing : es2015 as esm2015
Compiling @angular/compiler/testing : es2015 as esm2015
Compiling @angular/common/testing : es2015 as esm2015
Compiling @angular/common/http/testing : es2015 as esm2015
Compiling @angular/material/icon/testing : es2015 as esm2015
Compiling @angular/router/testing : es2015 as esm2015
Compiling @angular/platform-browser-dynamic/testing : es2015 as esm2015
29 03 2022 20:24:07.984:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
29 03 2022 20:24:07.984:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
29 03 2022 20:24:07.987:INFO [launcher]: Starting browser ChromeHeadless
29 03 2022 20:24:16.269:INFO [Chrome Headless 99.0.4844.83 (Mac OS 10.15.7)]: Connected on socket N1qZkZjixKkux56yAAAB with id 51382571
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at FilesystemPluginWeb.<anonymous> (http://localhost:9876/_karma_webpack_/vendor.js:153986:35)
            at step (http://localhost:9876/_karma_webpack_/vendor.js:342099:23)
            at Object.next (http://localhost:9876/_karma_webpack_/vendor.js:342080:53)
            at fulfilled (http://localhost:9876/_karma_webpack_/vendor.js:342070:58)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:340089:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.83 (Mac OS 10.15.7): Executed 221 of 221 (2 FAILED) (28.548 secs / 28.323 secs)
TOTAL: 2 FAILED, 219 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.94% ( 1849/3630 )
Branches     : 28.31% ( 295/1042 )
Functions    : 40.04% ( 643/1606 )
Lines        : 52.89% ( 1674/3165 )
================================================================================
➜  capture-lite git:(feature-support-0-parameter-network-action) 
```