### PR TITLE
feat: show how much point cover gas gee when transfering NUM

### DIFF
--- a/src/app/features/wallets/transfer/transfer.page.html
+++ b/src/app/features/wallets/transfer/transfer.page.html
@@ -93,13 +93,26 @@
         <ion-col size="2">
           <ion-icon name="wallet"></ion-icon>
         </ion-col>
-        <ion-col size="5" *ngrxLet="gasFee$ as gasFee">
+        <ion-col size="5">
           <h6>
             {{ t('wallets.gasFee') }}:
-            {{ gasFee > 0 ? (gasFee | number: '1.2-2') : t('wallets.pending') }}
+            {{
+              readyToSend
+                ? (gasFeeNumCharged > 0
+                    ? (gasFeeNumCharged | number: '1.2-2') + ' NUM'
+                    : '') +
+                  (gasFeeNumCharged > 0 && gasFeePointsCharged > 0
+                    ? ' + '
+                    : '') +
+                  (gasFeePointsCharged > 0
+                    ? (gasFeePointsCharged | number: '1.2-2') + ' Points'
+                    : '')
+                : t('wallets.pending')
+            }}
           </h6>
           <h4>
-            {{ t('wallets.total') }} {{ totalCost$ | ngrxPush | currency }}
+            {{ t('wallets.total') }}:
+            {{ readyToSend ? (totalCost | currency) : t('wallets.pending') }}
           </h4>
         </ion-col>
         <ion-col id="deposit-withdraw-btn-col">

--- a/src/app/features/wallets/transfer/transfer.page.ts
+++ b/src/app/features/wallets/transfer/transfer.page.ts
@@ -5,7 +5,7 @@ import { ActivatedRoute } from '@angular/router';
 import { NavController, Platform } from '@ionic/angular';
 import { TranslocoService } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { BehaviorSubject, merge, ObservableInput } from 'rxjs';
+import { merge, ObservableInput } from 'rxjs';
 import { catchError, finalize, mapTo, startWith, tap } from 'rxjs/operators';
 import { BlockingActionService } from '../../../shared/blocking-action/blocking-action.service';
 import { DiaBackendStoreService } from '../../../shared/dia-backend/store/dia-backend-store.service';
@@ -30,8 +30,9 @@ export class TransferPage {
 
   transferAmount: number | null = null;
 
-  readonly gasFee$ = new BehaviorSubject<number>(0);
-  readonly totalCost$ = new BehaviorSubject<number>(0);
+  gasFeeNumCharged = 0;
+  gasFeePointsCharged = 0;
+  totalCost = 0;
 
   readyToSend = false;
 
@@ -108,10 +109,11 @@ export class TransferPage {
       .pipe(
         tap(networkAppOrder => {
           this.orderId = networkAppOrder.id;
-          this.gasFee$.next(Number(networkAppOrder.fee));
-          this.totalCost$.next(
-            Number(networkAppOrder.fee) + Number(this.transferAmount)
-          );
+          this.gasFeePointsCharged = Number(networkAppOrder.points_charged);
+          this.gasFeeNumCharged =
+            Number(networkAppOrder.fee) -
+            Number(networkAppOrder.points_charged);
+          this.totalCost = Number(networkAppOrder.total_cost);
           this.readyToSend = true;
         }),
         catchError((err: unknown) => {

--- a/src/app/shared/dia-backend/store/dia-backend-store.service.ts
+++ b/src/app/shared/dia-backend/store/dia-backend-store.service.ts
@@ -67,6 +67,10 @@ export interface NetworkAppOrder {
   action_args: Record<string, unknown>;
   price: string;
   fee: string | null;
+  num_charged: string;
+  num_paid: string;
+  points_charged: string;
+  points_paid: string;
   total_cost: string;
   quantity: number;
   fund_crypto_transaction_id: string;


### PR DESCRIPTION
Display how much point and NUM user will be paying for gas fee when transferring NUM.

## Test Plan
### Before
![](https://user-images.githubusercontent.com/35753861/160755463-20dcc503-4306-466a-859c-44a83bd9bad9.png)

![](https://user-images.githubusercontent.com/35753861/160755022-f32ab7f9-c2f8-44db-9df4-6aa5b743d61b.png)

### After
![](https://user-images.githubusercontent.com/35753861/160755305-ab9b4d16-009d-47cd-b044-527678b26db9.png)

![](https://user-images.githubusercontent.com/35753861/160755241-fc180466-ab35-49e6-9e70-41f1af0b1477.png)

![](https://user-images.githubusercontent.com/35753861/160755275-6dc538d7-8820-4612-957b-aba261c4eb80.png)

![](https://user-images.githubusercontent.com/35753861/160755133-456e9cf8-12b5-4915-9c81-811d3e617f56.png)

```bash
➜  capture-lite git:(feature-show-points-cover-gas-gee-when-transfer-NUM) npm run test.ci

> capture-lite@0.52.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.52.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

30 03 2022 13:06:21.376:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
30 03 2022 13:06:21.377:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
30 03 2022 13:06:21.379:INFO [launcher]: Starting browser ChromeHeadless
30 03 2022 13:06:27.318:INFO [Chrome Headless 99.0.4844.84 (Mac OS 10.15.7)]: Connected on socket _kSEJPbdxcjlMo61AAAB with id 49346944
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: '<ion-refresher> must be used inside an <ion-content>'
ERROR: 'NG0304: 'mat-toolbar' is not a known element:
1. If 'mat-toolbar' is an Angular component, then verify that it is part of this module.
2. If 'mat-toolbar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-progress-bar' is not a known element:
1. If 'mat-progress-bar' is an Angular component, then verify that it is part of this module.
2. If 'mat-progress-bar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-icon' is not a known element:
1. If 'mat-icon' is an Angular component, then verify that it is part of this module.
2. If 'mat-icon' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: TypeError: config.get is not a function
TypeError: config.get is not a function
    at removeEventListener (http://localhost:9876/_karma_webpack_/vendor.js:177183:26)
    at SegmentButton.disconnectedCallback (http://localhost:9876/_karma_webpack_/node_modules_ionic_core_dist_esm_ion-segment_2_entry_js.js:484:62)
    at safeCall (http://localhost:9876/_karma_webpack_/vendor.js:179338:30)
    at disconnectedCallback (http://localhost:9876/_karma_webpack_/vendor.js:180022:7)
    at http://localhost:9876/_karma_webpack_/vendor.js:180128:23
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
    at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
    at NgZone.runOutsideAngular (http://localhost:9876/_karma_webpack_/vendor.js:92373:28), undefined
ERROR: TypeError: config.get is not a function
TypeError: config.get is not a function
    at removeEventListener (http://localhost:9876/_karma_webpack_/vendor.js:177183:26)
    at SegmentButton.disconnectedCallback (http://localhost:9876/_karma_webpack_/node_modules_ionic_core_dist_esm_ion-segment_2_entry_js.js:484:62)
    at safeCall (http://localhost:9876/_karma_webpack_/vendor.js:179338:30)
    at disconnectedCallback (http://localhost:9876/_karma_webpack_/vendor.js:180022:7)
    at http://localhost:9876/_karma_webpack_/vendor.js:180128:23
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
    at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
    at NgZone.runOutsideAngular (http://localhost:9876/_karma_webpack_/vendor.js:92373:28), undefined
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7): Executed 219 of 219 (2 FAILED) (28.229 secs / 28.012 secs)
TOTAL: 2 FAILED, 217 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.83% ( 1828/3596 )
Branches     : 27.82% ( 291/1046 )
Functions    : 40.01% ( 633/1582 )
Lines        : 52.78% ( 1654/3134 )
================================================================================
➜  capture-lite git:(feature-show-points-cover-gas-gee-when-transfer-NUM)
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1202051088907072) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
