### PR TITLE
feat: show insufficient NUM in order confirm dialog if applicable

### DIFF
--- a/src/app/shared/dia-backend/store/dia-backend-store.service.ts
+++ b/src/app/shared/dia-backend/store/dia-backend-store.service.ts
@@ -67,6 +67,10 @@ export interface NetworkAppOrder {
   action_args: Record<string, unknown>;
   price: string;
   fee: string | null;
+  num_charged: string;
+  num_paid: string;
+  points_charged: string;
+  points_paid: string;
   total_cost: string;
   quantity: number;
   fund_crypto_transaction_id: string;

--- a/src/app/shared/dia-backend/wallet/dia-backend-wallet.service.ts
+++ b/src/app/shared/dia-backend/wallet/dia-backend-wallet.service.ts
@@ -1,7 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { combineLatest, defer, forkJoin } from 'rxjs';
-import { concatMap, first } from 'rxjs/operators';
+import { catchError, concatMap, first } from 'rxjs/operators';
+import { ErrorService } from '../../error/error.service';
 import { NetworkService } from '../../network/network.service';
 import { PreferenceManager } from '../../preference-manager/preference-manager.service';
 import { DiaBackendAuthService } from '../auth/dia-backend-auth.service';
@@ -41,7 +42,8 @@ export class DiaBackendWalletService {
     private readonly httpClient: HttpClient,
     private readonly authService: DiaBackendAuthService,
     private readonly networkService: NetworkService,
-    private readonly preferenceManager: PreferenceManager
+    private readonly preferenceManager: PreferenceManager,
+    private readonly errorService: ErrorService
   ) {}
 
   getIntegrityWallet$() {
@@ -97,7 +99,8 @@ export class DiaBackendWalletService {
             diaBackendWallet.address
           ),
         ])
-      )
+      ),
+      catchError((err: unknown) => this.errorService.toastDiaBackendError$(err))
     );
   }
 

--- a/src/app/shared/order-detail-dialog/order-detail-dialog.component.html
+++ b/src/app/shared/order-detail-dialog/order-detail-dialog.component.html
@@ -1,33 +1,49 @@
 <div *transloco="let t">
-  <h2 mat-dialog-title>{{ t('payment.confirmPayment') }}</h2>
-  <ion-row style="border-bottom: groove">
-    <ion-col>
-      <ion-label>{{ t('payment.price') }}</ion-label>
-    </ion-col>
-    <ion-col align="end">
-      <ion-label>{{ orderStatus.price | number: '1.2-2' }} NUM</ion-label>
-    </ion-col>
-  </ion-row>
-  <ion-row style="border-bottom: groove">
-    <ion-col>
-      <ion-label>{{ t('payment.fee') }}</ion-label>
-    </ion-col>
-    <ion-col align="end">
-      <ion-label>{{ orderStatus.fee | number: '1.2-2' }} NUM</ion-label>
-    </ion-col>
-  </ion-row>
-  <ion-row>
-    <ion-col>
-      <ion-label>{{ t('payment.totalCost') }}</ion-label>
-    </ion-col>
-    <ion-col align="end">
-      <ion-label>{{ orderStatus.total_cost | number: '1.2-2' }} NUM</ion-label>
-    </ion-col>
-  </ion-row>
-  <mat-dialog-actions align="end">
-    <button mat-button (click)="cancel()">{{ t('cancel') }}</button>
-    <button mat-button color="primary" (click)="ok()">
-      {{ t('ok') }}
-    </button>
-  </mat-dialog-actions>
+  <div *ngrxLet="asset_wallet_bsc_num_balance$ as asset_wallet_bsc_num_balance">
+    <h2 mat-dialog-title>{{ t('payment.confirmPayment') }}</h2>
+    <ion-row style="border-bottom: groove">
+      <ion-col>
+        <ion-label>{{ t('payment.price') }}</ion-label>
+      </ion-col>
+      <ion-col align="end">
+        <ion-label>{{ orderStatus.price | number: '1.2-2' }} NUM</ion-label>
+      </ion-col>
+    </ion-row>
+    <ion-row style="border-bottom: groove">
+      <ion-col>
+        <ion-label>{{ t('payment.fee') }}</ion-label>
+      </ion-col>
+      <ion-col align="end">
+        <ion-label>{{ orderStatus.fee | number: '1.2-2' }} NUM</ion-label>
+      </ion-col>
+    </ion-row>
+    <ion-row>
+      <ion-col>
+        <ion-label>{{ t('payment.totalCost') }}</ion-label>
+      </ion-col>
+      <ion-col align="end">
+        <ion-label
+          >{{ orderStatus.total_cost | number: '1.2-2' }} NUM</ion-label
+        >
+      </ion-col>
+    </ion-row>
+    <ion-row *ngIf="asset_wallet_bsc_num_balance < num_charged">
+      <ion-col style="padding-top: 0; padding-bottom: 0" align="end">
+        <ion-label style="color: red; font-size: 15px">{{
+          t('insufficientNum')
+        }}</ion-label>
+      </ion-col>
+    </ion-row>
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="cancel()">{{ t('cancel') }}</button>
+      <button
+        [disabled]="asset_wallet_bsc_num_balance < num_charged"
+        mat-button
+        color="primary"
+        (click)="ok()"
+      >
+        {{ t('ok') }}
+      </button>
+    </mat-dialog-actions>
+  </div>
 </div>

--- a/src/app/shared/order-detail-dialog/order-detail-dialog.component.ts
+++ b/src/app/shared/order-detail-dialog/order-detail-dialog.component.ts
@@ -1,6 +1,7 @@
 import { Component, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { NetworkAppOrder } from '../dia-backend/store/dia-backend-store.service';
+import { DiaBackendWalletService } from '../dia-backend/wallet/dia-backend-wallet.service';
 
 @Component({
   selector: 'app-order-detail-dialog',
@@ -9,12 +10,17 @@ import { NetworkAppOrder } from '../dia-backend/store/dia-backend-store.service'
 })
 export class OrderDetailDialogComponent {
   readonly orderStatus: NetworkAppOrder;
+  num_charged = 0;
+  readonly asset_wallet_bsc_num_balance$ =
+    this.diaBackendWalletService.assetWalletBscNumBalance$;
 
   constructor(
     private readonly dialogRef: MatDialogRef<OrderDetailDialogComponent>,
+    private readonly diaBackendWalletService: DiaBackendWalletService,
     @Inject(MAT_DIALOG_DATA) public data: NetworkAppOrder
   ) {
     this.orderStatus = data;
+    this.num_charged = Number(data.num_charged);
   }
 
   ok() {

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -108,6 +108,7 @@
   "order": "Order",
   "resultUrl": "Result URL",
   "noResultUrlAvailable": "No Result URL available",
+  "insufficientNum": "Insufficient NUM",
   "verification": {
     "verification": "Verification",
     "clickToVerify": "Click me to verify",

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -107,6 +107,7 @@
   "copyToClipboard": "複製到剪貼簿",
   "order": "訂單",
   "resultUrl": "結果連結",
+  "insufficientNum": "NUM 餘額不足",
   "noResultUrlAvailable": "沒有可以顯示的結果連結",
   "verification": {
     "verification": "驗證",


### PR DESCRIPTION
Show insufficient NUM in order confirm dialog if applicable.

## Test Plan
<img width="426" alt="image" src="https://user-images.githubusercontent.com/35753861/160811924-35ddb906-7bcf-429f-b1a3-15bde7848740.png">


```bash
➜  capture-lite git:(feature-show-insufficient-NUM-in-order-confirm-dialog) npm run test.ci

> capture-lite@0.52.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.52.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

30 03 2022 18:29:20.243:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
30 03 2022 18:29:20.244:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
30 03 2022 18:29:20.247:INFO [launcher]: Starting browser ChromeHeadless
30 03 2022 18:29:27.406:INFO [Chrome Headless 99.0.4844.84 (Mac OS 10.15.7)]: Connected on socket cIU3OEX8wRoUV3XOAAAB with id 41708774
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: 'NG0304: 'mat-toolbar' is not a known element:
1. If 'mat-toolbar' is an Angular component, then verify that it is part of this module.
2. If 'mat-toolbar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-progress-bar' is not a known element:
1. If 'mat-progress-bar' is an Angular component, then verify that it is part of this module.
2. If 'mat-progress-bar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-icon' is not a known element:
1. If 'mat-icon' is an Angular component, then verify that it is part of this module.
2. If 'mat-icon' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: '<ion-refresher> must be used inside an <ion-content>'
ERROR: TypeError: config.get is not a function
TypeError: config.get is not a function
    at removeEventListener (http://localhost:9876/_karma_webpack_/vendor.js:177183:26)
    at SegmentButton.disconnectedCallback (http://localhost:9876/_karma_webpack_/node_modules_ionic_core_dist_esm_ion-segment_2_entry_js.js:484:62)
    at safeCall (http://localhost:9876/_karma_webpack_/vendor.js:179338:30)
    at disconnectedCallback (http://localhost:9876/_karma_webpack_/vendor.js:180022:7)
    at http://localhost:9876/_karma_webpack_/vendor.js:180128:23
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
    at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
    at NgZone.runOutsideAngular (http://localhost:9876/_karma_webpack_/vendor.js:92373:28), undefined
ERROR: TypeError: config.get is not a function
TypeError: config.get is not a function
    at removeEventListener (http://localhost:9876/_karma_webpack_/vendor.js:177183:26)
    at SegmentButton.disconnectedCallback (http://localhost:9876/_karma_webpack_/node_modules_ionic_core_dist_esm_ion-segment_2_entry_js.js:484:62)
    at safeCall (http://localhost:9876/_karma_webpack_/vendor.js:179338:30)
    at disconnectedCallback (http://localhost:9876/_karma_webpack_/vendor.js:180022:7)
    at http://localhost:9876/_karma_webpack_/vendor.js:180128:23
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
    at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
    at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
    at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
    at NgZone.runOutsideAngular (http://localhost:9876/_karma_webpack_/vendor.js:92373:28), undefined
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7): Executed 219 of 219 (2 FAILED) (28.471 secs / 28.241 secs)
TOTAL: 2 FAILED, 217 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.72% ( 1827/3602 )
Branches     : 27.63% ( 289/1046 )
Functions    : 39.77% ( 630/1584 )
Lines        : 52.64% ( 1654/3142 )
================================================================================
➜  capture-lite git:(feature-show-insufficient-NUM-in-order-confirm-dialog) 
```
