### PR TITLE
feat: show update app reminder if user get 401 error when create orde…

### DIFF
--- a/src/app/shared/confirm-alert/confirm-alert.service.ts
+++ b/src/app/shared/confirm-alert/confirm-alert.service.ts
@@ -16,29 +16,35 @@ export class ConfirmAlert {
     message = this.translocoService.translate('message.areYouSure'),
     confirmButtonText = this.translocoService.translate('ok'),
     cancelButtonText = this.translocoService.translate('cancel'),
+    showCancelButton = true,
   }: {
     header?: string;
     message?: string;
     confirmButtonText?: string;
     cancelButtonText?: string;
+    showCancelButton?: boolean;
   } = {}) {
     return new Promise<boolean>(resolve => {
+      const buttons: any[] = [
+        {
+          text: confirmButtonText ?? this.translocoService.translate('ok'),
+          handler: () => resolve(true),
+        },
+      ];
+
+      if (showCancelButton) {
+        buttons.unshift({
+          text: cancelButtonText ?? this.translocoService.translate('cancel'),
+          role: 'cancel',
+          handler: () => resolve(false),
+        });
+      }
+
       this.alertController
         .create({
           header,
           message,
-          buttons: [
-            {
-              text:
-                cancelButtonText ?? this.translocoService.translate('cancel'),
-              role: 'cancel',
-              handler: () => resolve(false),
-            },
-            {
-              text: confirmButtonText ?? this.translocoService.translate('ok'),
-              handler: () => resolve(true),
-            },
-          ],
+          buttons: buttons,
           mode: 'md',
           backdropDismiss: false,
         })

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -109,6 +109,7 @@
   "resultUrl": "Result URL",
   "noResultUrlAvailable": "No Result URL available",
   "insufficientNum": "Insufficient NUM",
+  "updateCaptureApp": "Update Capture App",
   "verification": {
     "verification": "Verification",
     "clickToVerify": "Click me to verify",
@@ -185,7 +186,8 @@
     "mintNftAlert": "Once the NFT is minted, photo and its information can be accessed publicly. Do you still want to proceed?",
     "sentSuccessfully": "Sent Successfully",
     "confirmCopyPrivateKey": "Warning: Please do not expose your private key to anyone. Lost of private key may cause your account to be lost permanently.",
-    "hasListedInCaptureClub": "This asset has already been listed in CaptureClub."
+    "hasListedInCaptureClub": "This asset has already been listed in CaptureClub.",
+    "pleaseUpdateCaptureAppBubbleDBAuth": "Please update your Capture App to the latest version to ensure a smooth network action experience!"
   },
   "error": {
     "validationError": "Invalid operation. Please check your input again.",

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -109,6 +109,7 @@
   "resultUrl": "結果連結",
   "insufficientNum": "NUM 餘額不足",
   "noResultUrlAvailable": "沒有可以顯示的結果連結",
+  "updateCaptureApp": "更新 Capture App",
   "verification": {
     "verification": "驗證",
     "clickToVerify": "點擊驗證",
@@ -185,7 +186,8 @@
     "mintNftAlert": "NFT 代幣鑄造後，影像以及所有資訊都將可被公開檢視。確定要繼續嗎？",
     "sentSuccessfully": "成功送出",
     "confirmCopyPrivateKey": "警告：請不要向任何人揭露您的金鑰，未保管好金鑰可能導致您永遠失去您的帳號。",
-    "hasListedInCaptureClub": "該資產已在 CaptureClub 上架。"
+    "hasListedInCaptureClub": "該資產已在 CaptureClub 上架。",
+    "pleaseUpdateCaptureAppBubbleDBAuth": "請將您的 Capture App 更新到最新版本以確保順暢網絡動作體驗！"
   },
   "error": {
     "validationError": "操作或輸入有誤，請確認您的操作正確。",


### PR DESCRIPTION
Show update app reminder if user get 401 error when create order history record. Once bubble order db api token protection is released, Capture App version < 0.53.0 will not be able to create network order history from app. 

## Test Plan
![](https://user-images.githubusercontent.com/35753861/160832712-5ff3ca12-619d-40db-ae4d-2c4e8fdd289f.png)

```bash
➜  capture-lite git:(feature-remind-user-to-update-app-if-order-history-creation-fail) npm run test.ci

> capture-lite@0.52.1 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.52.1 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

30 03 2022 20:18:50.848:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
30 03 2022 20:18:50.849:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
30 03 2022 20:18:50.852:INFO [launcher]: Starting browser ChromeHeadless
30 03 2022 20:18:57.578:INFO [Chrome Headless 99.0.4844.84 (Mac OS 10.15.7)]: Connected on socket sLxCg9H54g17awxVAAAB with id 85013195
ERROR: 'NG0304: 'mat-toolbar' is not a known element:
1. If 'mat-toolbar' is an Angular component, then verify that it is part of this module.
2. If 'mat-toolbar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-progress-bar' is not a known element:
1. If 'mat-progress-bar' is an Angular component, then verify that it is part of this module.
2. If 'mat-progress-bar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-icon' is not a known element:
1. If 'mat-icon' is an Angular component, then verify that it is part of this module.
2. If 'mat-icon' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7): Executed 219 of 219 (2 FAILED) (28.208 secs / 27.995 secs)
TOTAL: 2 FAILED, 217 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.91% ( 1838/3610 )
Branches     : 27.92% ( 294/1053 )
Functions    : 39.96% ( 633/1584 )
Lines        : 52.84% ( 1664/3149 )
================================================================================
➜  capture-lite git:(feature-remind-user-to-update-app-if-order-history-creation-fail)
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1202049367477692) by [Unito](https://www.unito.io)
