### PR TITLE
Feature download asset using cdn

### DIFF
--- a/src/app/features/home/capture-tab/capture-tab.component.ts
+++ b/src/app/features/home/capture-tab/capture-tab.component.ts
@@ -99,7 +99,7 @@ export class CaptureTabComponent {
 
   refreshCaptures(event: Event) {
     this.diaBackendAssetRefreshingService
-      .refresh()
+      .refresh$()
       .pipe(finalize(() => (<CustomEvent>event).detail.complete()))
       .subscribe();
   }

--- a/src/app/features/home/details/information/session/information-session.service.ts
+++ b/src/app/features/home/details/information/session/information-session.service.ts
@@ -52,7 +52,7 @@ export class DetailedCapture {
         const [index, meta] = Object.entries(proof.indexedAssets)[0];
         if (!(await this.mediaStore.exists(index)) && proof.diaBackendAssetId) {
           const mediaBlob = await this.diaBackendAssetRepository
-            .downloadFile$({ id: proof.diaBackendAssetId, field: 'asset_file' })
+            .downloadAssetFileFromCDN$(proof.diaBackendAssetId)
             .pipe(
               first(),
               catchError((err: unknown) => this.errorService.toastError$(err))
@@ -63,7 +63,6 @@ export class DetailedCapture {
         return proof.getFirstAssetUrl();
       });
     }
-
     return this.diaBackendAsset$.pipe(
       isNonNullable(),
       switchMap(asset =>

--- a/src/app/shared/dia-backend/asset/downloading/dia-backend-downloading.service.ts
+++ b/src/app/shared/dia-backend/asset/downloading/dia-backend-downloading.service.ts
@@ -1,6 +1,5 @@
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { first } from 'rxjs/operators';
 import { blobToBase64 } from '../../../../utils/encoding/encoding';
 import { OnConflictStrategy } from '../../../database/table/table';
 import { HttpErrorCode } from '../../../error/error.service';
@@ -23,7 +22,8 @@ export class DiaBackendAssetDownloadingService {
   constructor(
     private readonly assetRepository: DiaBackendAssetRepository,
     private readonly mediaStore: MediaStore,
-    private readonly proofRepository: ProofRepository
+    private readonly proofRepository: ProofRepository,
+    private readonly httpClient: HttpClient
   ) {}
 
   async storeRemoteCapture(diaBackendAsset: DiaBackendAsset) {
@@ -43,9 +43,11 @@ export class DiaBackendAssetDownloadingService {
     if (!diaBackendAsset.information.proof) {
       return;
     }
-    const thumbnailBlob = await this.assetRepository
-      .downloadFile$({ id: diaBackendAsset.id, field: 'asset_file_thumbnail' })
-      .pipe(first())
+    // This function is only called by storeRemoteCapture, which should always
+    // get diaBackendAsset from backend. That should mean we're always using
+    // up-to-date asset_file_thumbnail cdn link.
+    const thumbnailBlob = await this.httpClient
+      .get(diaBackendAsset.asset_file_thumbnail, { responseType: 'blob' })
       .toPromise();
     return this.mediaStore.storeThumbnail(
       diaBackendAsset.proof_hash,


### PR DESCRIPTION
* Download asset thumbnail and asset file through cdn
* Fix refresh not working when there's no Capture

## Test Plan
### Before
https://www.youtube.com/shorts/MQ9c4NMVnMQ

### After
https://youtube.com/shorts/GPakD0a0Seo?feature=share

```bash
➜  capture-lite git:(feature-download-asset-using-cdn) npm run test.ci

> capture-lite@0.53.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.53.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

31 03 2022 21:47:32.761:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
31 03 2022 21:47:32.762:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
31 03 2022 21:47:32.765:INFO [launcher]: Starting browser ChromeHeadless
31 03 2022 21:47:39.713:INFO [Chrome Headless 99.0.4844.84 (Mac OS 10.15.7)]: Connected on socket eZbaYXbvMs7uNEieAAAB with id 8011767
ERROR: 'NG0304: 'mat-toolbar' is not a known element:
1. If 'mat-toolbar' is an Angular component, then verify that it is part of this module.
2. If 'mat-toolbar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-progress-bar' is not a known element:
1. If 'mat-progress-bar' is an Angular component, then verify that it is part of this module.
2. If 'mat-progress-bar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-icon' is not a known element:
1. If 'mat-icon' is an Angular component, then verify that it is part of this module.
2. If 'mat-icon' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7): Executed 219 of 219 (1 FAILED) (27.955 secs / 27.753 secs)
TOTAL: 1 FAILED, 218 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.69% ( 1828/3606 )
Branches     : 27.58% ( 289/1048 )
Functions    : 39.72% ( 630/1586 )
Lines        : 52.62% ( 1655/3145 )
================================================================================
➜  capture-lite git:(feature-download-asset-using-cdn)
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1202058574736822) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
