### PR TITLE
fix: remove the Capture after Gift a Capture or Web 3 archive network…

### DIFF
--- a/src/app/features/home/details/actions/actions.page.ts
+++ b/src/app/features/home/details/actions/actions.page.ts
@@ -221,10 +221,8 @@ export class ActionsPage {
         catchError((err: unknown) => {
           return this.errorService.toastError$(err);
         }),
-        concatMap(() =>
-          combineLatest([this.openActionDialog$(action), of(action)])
-        ),
-        concatMap(([createOrderInput, action]) =>
+        concatMap(() => this.openActionDialog$(action)),
+        concatMap(createOrderInput =>
           this.blockingActionService.run$(
             forkJoin([
               this.createOrder$(

--- a/src/app/features/home/details/actions/actions.page.ts
+++ b/src/app/features/home/details/actions/actions.page.ts
@@ -201,23 +201,16 @@ export class ActionsPage {
     );
   }
 
-  postActionProcedure(networkAppOrder: NetworkAppOrder) {
-    // Since "Gift a Capture" and "Web 3.0 Archive" are essentially Capture
-    // transaction, we want to have the Capture removed after order is submitted.
-    if (
-      networkAppOrder.network_app_name === 'Gift a Capture' ||
-      networkAppOrder.network_app_name === 'Web 3.0 Archive'
-    ) {
-      if (this.informationSessionService.activatedDetailedCapture) {
-        this.informationSessionService.activatedDetailedCapture.proof$.subscribe(
-          proof => {
-            if (proof) {
-              this.proofRepository.remove(proof);
-              this.router.navigate(['/home']);
-            }
+  removeCapture() {
+    if (this.informationSessionService.activatedDetailedCapture) {
+      this.informationSessionService.activatedDetailedCapture.proof$.subscribe(
+        proof => {
+          if (proof) {
+            this.proofRepository.remove(proof);
+            this.router.navigate(['/home']);
           }
-        );
-      }
+        }
+      );
     }
   }
 
@@ -270,7 +263,10 @@ export class ActionsPage {
             this.translocoService.translate('message.sentSuccessfully')
           );
         }),
-        tap(networkAppOrder => this.postActionProcedure(networkAppOrder)),
+        tap(() => {
+          if (action.hide_capture_after_execution_boolean ?? false)
+            this.removeCapture();
+        }),
         untilDestroyed(this)
       )
       .subscribe();

--- a/src/app/shared/actions/service/actions.service.ts
+++ b/src/app/shared/actions/service/actions.service.ts
@@ -44,6 +44,7 @@ export interface Action {
   readonly params_list_custom_param1?: string[];
   readonly title_text: string;
   readonly network_app_id_text: string;
+  readonly hide_capture_after_execution_boolean?: boolean;
 }
 
 export interface Param {


### PR DESCRIPTION
Remove the Capture after Gift a Capture or Web 3 archive network action order is submitted.
See https://github.com/numbersprotocol/capture-lite/issues/1129

## Test Plan
Demo: https://youtube.com/shorts/TbmkazOTiZc

```bash
➜  capture-lite git:(fix-remove-Capture-after-gift-a-Capture-or-Web-3-archive) npm run test.ci

> capture-lite@0.53.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.53.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

31 03 2022 22:34:44.368:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
31 03 2022 22:34:44.382:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
31 03 2022 22:34:44.390:INFO [launcher]: Starting browser ChromeHeadless
31 03 2022 22:34:50.706:INFO [Chrome Headless 99.0.4844.84 (Mac OS 10.15.7)]: Connected on socket yfyqtSTfjyG0d5pBAAAB with id 9350795
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: 'NG0304: 'mat-toolbar' is not a known element:
1. If 'mat-toolbar' is an Angular component, then verify that it is part of this module.
2. If 'mat-toolbar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-progress-bar' is not a known element:
1. If 'mat-progress-bar' is an Angular component, then verify that it is part of this module.
2. If 'mat-progress-bar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-icon' is not a known element:
1. If 'mat-icon' is an Angular component, then verify that it is part of this module.
2. If 'mat-icon' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 99.0.4844.84 (Mac OS 10.15.7): Executed 219 of 219 (2 FAILED) (28.049 secs / 27.847 secs)
TOTAL: 2 FAILED, 217 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.66% ( 1830/3612 )
Branches     : 27.42% ( 289/1054 )
Functions    : 39.7% ( 630/1587 )
Lines        : 52.59% ( 1657/3151 )
================================================================================
➜  capture-lite git:(fix-remove-Capture-after-gift-a-Capture-or-Web-3-archive)
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1202058574604279) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
