### PR TITLE
feat: implement buy NUM button

### DIFF
--- a/src/app/features/wallets/wallets.page.html
+++ b/src/app/features/wallets/wallets.page.html
@@ -48,7 +48,7 @@
       </ion-row>
       <ion-row id="buy-deposit-withdraw-row">
         <ion-button
-          hidden
+          (click)="onBuyNumBtnClicked()"
           id="buy-num-btn"
           size="small"
           class="num-operation-btn"

--- a/src/app/features/wallets/wallets.page.ts
+++ b/src/app/features/wallets/wallets.page.ts
@@ -82,7 +82,7 @@ export class WalletsPage {
   // eslint-disable-next-line class-methods-use-this
   onBuyNumBtnClicked() {
     Browser.open({
-      url: `https://buy.num.indacoin.io/`,
+      url: `https://link.numbersprotocol.io/buy-num`,
       toolbarColor: '#564dfc',
     });
   }

--- a/src/app/features/wallets/wallets.page.ts
+++ b/src/app/features/wallets/wallets.page.ts
@@ -3,9 +3,9 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatIconRegistry } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { DomSanitizer } from '@angular/platform-browser';
+import { Router } from '@angular/router';
 import { Browser } from '@capacitor/browser';
 import { Clipboard } from '@capacitor/clipboard';
-import { Router } from '@angular/router';
 import { TranslocoService } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { BehaviorSubject, combineLatest, forkJoin } from 'rxjs';
@@ -77,6 +77,14 @@ export class WalletsPage {
         untilDestroyed(this)
       )
       .subscribe(totalBalance => this.totalBalance$.next(totalBalance));
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  onBuyNumBtnClicked() {
+    Browser.open({
+      url: `https://buy.num.indacoin.io/`,
+      toolbarColor: '#564dfc',
+    });
   }
 
   openNUMTransactionHistory() {


### PR DESCRIPTION
Implement buy NUM button and have it point to https://buy.num.indacoin.io/. See https://github.com/numbersprotocol/capture-lite/issues/1469

## Test Plan
Demo: https://youtube.com/shorts/m4feXidjmwE?feature=share

```bash
➜  capture-lite git:(feature-buy-num-button) npm run test.ci

> capture-lite@0.53.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.53.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

01 04 2022 22:09:58.794:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
01 04 2022 22:09:58.795:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
01 04 2022 22:09:58.797:INFO [launcher]: Starting browser ChromeHeadless
01 04 2022 22:10:05.345:INFO [Chrome Headless 100.0.4896.60 (Mac OS 10.15.7)]: Connected on socket gropkjrrE0qb16pWAAAB with id 81957259
Chrome Headless 100.0.4896.60 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 100.0.4896.60 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-toolbar' is not a known element:
1. If 'mat-toolbar' is an Angular component, then verify that it is part of this module.
2. If 'mat-toolbar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-progress-bar' is not a known element:
1. If 'mat-progress-bar' is an Angular component, then verify that it is part of this module.
2. If 'mat-progress-bar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-icon' is not a known element:
1. If 'mat-icon' is an Angular component, then verify that it is part of this module.
2. If 'mat-icon' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 100.0.4896.60 (Mac OS 10.15.7): Executed 219 of 219 (2 FAILED) (28.43 secs / 28.214 secs)
TOTAL: 2 FAILED, 217 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.71% ( 1827/3603 )
Branches     : 27.63% ( 289/1046 )
Functions    : 39.75% ( 630/1585 )
Lines        : 52.64% ( 1654/3142 )
================================================================================
➜  capture-lite git:(feature-buy-num-button) 
```
