### PR TITLE
feat: skip storing asset thumbnail for cached assets

### DIFF
--- a/src/app/shared/dia-backend/asset/downloading/dia-backend-downloading.service.ts
+++ b/src/app/shared/dia-backend/asset/downloading/dia-backend-downloading.service.ts
@@ -26,15 +26,20 @@ export class DiaBackendAssetDownloadingService {
     private readonly proofRepository: ProofRepository
   ) {}
 
-  async storeRemoteCapture(diaBackendAsset: DiaBackendAsset) {
-    try {
-      await this.storeAssetThumbnail(diaBackendAsset);
-    } catch (e: unknown) {
-      if (
-        !(e instanceof HttpErrorResponse) ||
-        !(e.status === HttpErrorCode.NOT_FOUND)
-      )
-        throw e;
+  async storeRemoteCapture(
+    diaBackendAsset: DiaBackendAsset,
+    storeAssetThumbnail = true
+  ) {
+    if (storeAssetThumbnail) {
+      try {
+        await this.storeAssetThumbnail(diaBackendAsset);
+      } catch (e: unknown) {
+        if (
+          !(e instanceof HttpErrorResponse) ||
+          !(e.status === HttpErrorCode.NOT_FOUND)
+        )
+          throw e;
+      }
     }
     return this.storeIndexedProof(diaBackendAsset);
   }

--- a/src/app/shared/dia-backend/asset/prefetching/dia-backend-asset-prefetching.service.ts
+++ b/src/app/shared/dia-backend/asset/prefetching/dia-backend-asset-prefetching.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { MediaStore } from '../../../media/media-store/media-store.service';
 import { DiaBackendAssetRepository } from '../dia-backend-asset-repository.service';
 import { DiaBackendAssetDownloadingService } from '../downloading/dia-backend-downloading.service';
 
@@ -8,7 +9,8 @@ import { DiaBackendAssetDownloadingService } from '../downloading/dia-backend-do
 export class DiaBackendAssetPrefetchingService {
   constructor(
     private readonly assetRepository: DiaBackendAssetRepository,
-    private readonly downloadingService: DiaBackendAssetDownloadingService
+    private readonly downloadingService: DiaBackendAssetDownloadingService,
+    private readonly mediaStore: MediaStore
   ) {}
 
   async prefetch(
@@ -29,7 +31,12 @@ export class DiaBackendAssetPrefetchingService {
       await Promise.all(
         diaBackendAssets.map(async diaBackendAsset => {
           if (diaBackendAsset.source_transaction === null)
-            await this.downloadingService.storeRemoteCapture(diaBackendAsset);
+            await this.downloadingService.storeRemoteCapture(
+              diaBackendAsset,
+              (await this.mediaStore.getThumbnail(
+                diaBackendAsset.proof_hash
+              )) === undefined
+            );
           currentCount += 1;
           onStored(currentCount, totalCount);
         })

--- a/src/app/shared/media/media-store/media-store.service.ts
+++ b/src/app/shared/media/media-store/media-store.service.ts
@@ -222,7 +222,7 @@ export class MediaStore {
     return index;
   }
 
-  private async getThumbnail(index: string) {
+  async getThumbnail(index: string) {
     const thumbnails = await this.thumbnailTable.queryAll();
     return thumbnails.find(thumb => thumb.imageIndex === index);
   }


### PR DESCRIPTION
Skip storing asset thumbnail for assets that have already been cached locally. I believe asset thumbnail won't really changed once they're created. So why store it each time we refresh?

This should reduce backend workload and significantly improve Capture App refresh performance : )

## Test Plan
### Before: 
https://youtu.be/pgW3wliFn_A

### After:
https://youtu.be/95QD1v8YOn4

```bash
➜  capture-lite git:(feature-skip-storing-thumbnail-for-cached-assets) npm run test.ci

> capture-lite@0.53.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.53.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

06 04 2022 17:40:11.771:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
06 04 2022 17:40:11.772:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
06 04 2022 17:40:11.773:INFO [launcher]: Starting browser ChromeHeadless
06 04 2022 17:40:18.386:INFO [Chrome Headless 100.0.4896.75 (Mac OS 10.15.7)]: Connected on socket 4oWAI_mjrQ51Y9wQAAAB with id 75887505
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-toolbar' is not a known element:
1. If 'mat-toolbar' is an Angular component, then verify that it is part of this module.
2. If 'mat-toolbar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-progress-bar' is not a known element:
1. If 'mat-progress-bar' is an Angular component, then verify that it is part of this module.
2. If 'mat-progress-bar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-icon' is not a known element:
1. If 'mat-icon' is an Angular component, then verify that it is part of this module.
2. If 'mat-icon' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: '<ion-refresher> must be used inside an <ion-content>'
Chrome Headless 100.0.4896.75 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 100.0.4896.75 (Mac OS 10.15.7): Executed 219 of 219 (1 FAILED) (26.56 secs / 26.353 secs)
TOTAL: 1 FAILED, 218 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.98% ( 1838/3605 )
Branches     : 27.84% ( 292/1049 )
Functions    : 40.09% ( 635/1584 )
Lines        : 52.93% ( 1664/3144 )
================================================================================
➜  capture-lite git:(feature-skip-storing-thumbnail-for-cached-assets) 
```



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1202063748816624) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
