### PR TITLE
feat: support redirecting to other site after submitting network acti…

### DIFF
--- a/src/app/features/home/details/actions/actions.page.ts
+++ b/src/app/features/home/details/actions/actions.page.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
+import { Browser } from '@capacitor/browser';
 import { TranslocoService } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { combineLatest, forkJoin, iif, of } from 'rxjs';
@@ -196,6 +197,25 @@ export class ActionsPage {
     );
   }
 
+  redirectToExternalUrl(url: string, orderId: string) {
+    this.id$
+      .pipe(
+        first(),
+        isNonNullable(),
+        tap(cid =>
+          Browser.open({
+            url: `${url}?cid=${cid}&order_id=${orderId}`,
+            toolbarColor: '#564dfc',
+          })
+        ),
+        catchError((err: unknown) => {
+          return this.errorService.toastError$(err);
+        }),
+        untilDestroyed(this)
+      )
+      .subscribe();
+  }
+
   doAction(action: Action) {
     this.blockingActionService
       .run$(this.canPerformAction$(action))
@@ -244,6 +264,14 @@ export class ActionsPage {
           this.snackBar.open(
             this.translocoService.translate('message.sentSuccessfully')
           );
+        }),
+        tap(networkAppOrder => {
+          if (action.ext_action_destination_text) {
+            this.redirectToExternalUrl(
+              action.ext_action_destination_text,
+              networkAppOrder.id
+            );
+          }
         }),
         untilDestroyed(this)
       )

--- a/src/app/shared/actions/service/actions.service.ts
+++ b/src/app/shared/actions/service/actions.service.ts
@@ -44,6 +44,7 @@ export interface Action {
   readonly params_list_custom_param1?: string[];
   readonly title_text: string;
   readonly network_app_id_text: string;
+  readonly ext_action_destination_text?: string;
 }
 
 export interface Param {


### PR DESCRIPTION
See https://github.com/numbersprotocol/capture-lite/issues/1382. 

## Test Plan
Demo Video: https://youtube.com/shorts/H12BXNQeI-c
I set the `ext_action_destination` of `Upload to Web 3.0 Storage` to `https://web3.storage/` temporarily to test this feature.

```bash
➜  capture-lite git:(feature-support-redirecting-to-other-site-after-submitting-network-action-order) ✗ npm run test.ci

> capture-lite@0.53.0 test.ci
> npm run preconfig && ng test --no-watch --no-progress --source-map=false --browsers=ChromeHeadlessCI


> capture-lite@0.53.0 preconfig
> node set-secret.js

A secret file has generated successfully at ./src/app/shared/dia-backend/secret.ts 

06 04 2022 16:56:37.141:INFO [karma-server]: Karma v6.3.4 server started at http://localhost:9876/
06 04 2022 16:56:37.142:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited
06 04 2022 16:56:37.144:INFO [launcher]: Starting browser ChromeHeadless
06 04 2022 16:56:44.088:INFO [Chrome Headless 100.0.4896.75 (Mac OS 10.15.7)]: Connected on socket vd5qa626umTRYm3SAAAB with id 41474646
Chrome Headless 100.0.4896.75 (Mac OS 10.15.7) MediaStore should write atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:171:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
Chrome Headless 100.0.4896.75 (Mac OS 10.15.7) MediaStore should delete atomicly FAILED
        Error: Timeout - Async function did not complete within 5000ms (set by jasmine.DEFAULT_TIMEOUT_INTERVAL)
            at <Jasmine>
        Error: File does not exist.
            at http://localhost:9876/_karma_webpack_/node_modules_capacitor_filesystem_dist_esm_web_js.js:293:38
            at Generator.next (<anonymous>)
            at asyncGeneratorStep (http://localhost:9876/_karma_webpack_/vendor.js:348327:24)
            at _next (http://localhost:9876/_karma_webpack_/vendor.js:348349:9)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8285:26)
            at ProxyZoneSpec.onInvoke (http://localhost:9876/_karma_webpack_/vendor.js:338547:39)
            at ZoneDelegate.invoke (http://localhost:9876/_karma_webpack_/polyfills.js:8284:52)
            at Zone.run (http://localhost:9876/_karma_webpack_/polyfills.js:8047:43)
            at http://localhost:9876/_karma_webpack_/polyfills.js:9189:36
            at ZoneDelegate.invokeTask (http://localhost:9876/_karma_webpack_/polyfills.js:8319:31)
ERROR: 'NG0304: 'mat-toolbar' is not a known element:
1. If 'mat-toolbar' is an Angular component, then verify that it is part of this module.
2. If 'mat-toolbar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-progress-bar' is not a known element:
1. If 'mat-progress-bar' is an Angular component, then verify that it is part of this module.
2. If 'mat-progress-bar' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: 'NG0304: 'mat-icon' is not a known element:
1. If 'mat-icon' is an Angular component, then verify that it is part of this module.
2. If 'mat-icon' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
ERROR: '<ion-refresher> must be used inside an <ion-content>'
ERROR: 'NG0304: 'app-capture-transactions' is not a known element:
1. If 'app-capture-transactions' is an Angular component, then verify that it is part of this module.
2. If 'app-capture-transactions' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.'
Chrome Headless 100.0.4896.75 (Mac OS 10.15.7): Executed 219 of 219 (2 FAILED) (29.083 secs / 28.85 secs)
TOTAL: 2 FAILED, 217 SUCCESS

=============================== Coverage summary ===============================
Statements   : 50.65% ( 1827/3607 )
Branches     : 27.58% ( 289/1048 )
Functions    : 39.67% ( 630/1588 )
Lines        : 52.57% ( 1654/3146 )
================================================================================
➜  capture-lite git:(feature-support-redirecting-to-other-site-after-submitting-network-action-order) ✗ 
```