### PR TITLE
fix: install preview-camera plugin from branch release-0.0.2-auto-rot…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@ngx-formly/core": "^5.10.22",
         "@ngx-formly/material": "^5.10.22",
         "@ngx-formly/schematics": "^5.10.22",
-        "@numbersprotocol/preview-camera": "github:numbersprotocol/preview-camera",
+        "@numbersprotocol/preview-camera": "github:numbersprotocol/preview-camera#release-0.0.2-auto-rotate-fix",
         "@numbersprotocol/preview-video": "github:numbersprotocol/preview-video",
         "async-mutex": "^0.3.2",
         "buffer": "^5.7.1",
@@ -4120,8 +4120,8 @@
       }
     },
     "node_modules/@numbersprotocol/preview-camera": {
-      "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#6bbe8d2495d3b25238952ec442525405b0d9a48b",
+      "version": "0.0.2",
+      "resolved": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#2ce3dc63f83780c4c8e7afe8291238b9c838eb5c",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^3.0.0"
@@ -28245,8 +28245,8 @@
       }
     },
     "@numbersprotocol/preview-camera": {
-      "version": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#6bbe8d2495d3b25238952ec442525405b0d9a48b",
-      "from": "@numbersprotocol/preview-camera@github:numbersprotocol/preview-camera",
+      "version": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#2ce3dc63f83780c4c8e7afe8291238b9c838eb5c",
+      "from": "@numbersprotocol/preview-camera@github:numbersprotocol/preview-camera#release-0.0.2-auto-rotate-fix",
       "requires": {}
     },
     "@numbersprotocol/preview-video": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@ngx-formly/core": "^5.10.22",
     "@ngx-formly/material": "^5.10.22",
     "@ngx-formly/schematics": "^5.10.22",
-    "@numbersprotocol/preview-camera": "github:numbersprotocol/preview-camera",
+    "@numbersprotocol/preview-camera": "github:numbersprotocol/preview-camera#release-0.0.2-auto-rotate-fix",
     "@numbersprotocol/preview-video": "github:numbersprotocol/preview-video",
     "async-mutex": "^0.3.2",
     "buffer": "^5.7.1",


### PR DESCRIPTION
James this time I just reinstall preview-camera plugin from separate branch [release-0.0.2-auto-rotate-fix](https://github.com/numbersprotocol/preview-camera/tree/release-0.0.2-auto-rotate-fix). Tested on local iOS, Android worked as expected now I just need to republish as 0.56.1 so it can be go through Q&A from TestFlight etc.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1202263338227976) by [Unito](https://www.unito.io)
┆Created By: Tammy Yang
