### PR TITLE
Build bump 0.56.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.56.3 - 2022-05-13
+
+### Changed
+
+- Hide Buy NUM button from Wallets page
+
 ## 0.56.2 - 2022-05-12
 
 ### Fixed

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "io.numbersprotocol.capturelite"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 392
-        versionName "0.56.2"
+        versionCode 393
+        versionName "0.56.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildFeatures {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capture-lite",
-  "version": "0.56.2",
+  "version": "0.56.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "capture-lite",
-      "version": "0.56.2",
+      "version": "0.56.3",
       "dependencies": {
         "@angular/animations": "^12.2.4",
         "@angular/cdk": "^12.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capture-lite",
-  "version": "0.56.2",
+  "version": "0.56.3",
   "author": "numbersprotocol",
   "homepage": "https://numbersprotocol.io/",
   "scripts": {

--- a/src/app/features/wallets/wallets.page.html
+++ b/src/app/features/wallets/wallets.page.html
@@ -49,13 +49,13 @@
         >
       </ion-row>
       <ion-row id="buy-deposit-withdraw-row">
-        <ion-button
+        <!-- <ion-button
           (click)="onBuyNumBtnClicked()"
           id="buy-num-btn"
           size="small"
           class="num-operation-btn"
           >{{ t('buy') }} NUM</ion-button
-        >
+        > -->
         <ion-button
           class="deposit-withdraw-num-btn num-operation-btn"
           color="#7E7E7E"


### PR DESCRIPTION
- Hide buy NUM button from Wallets page
- Bump version
in one branch
![hide Buy NUM button](https://user-images.githubusercontent.com/104349725/168203335-143dde08-14ae-4590-a28a-c0f8522b1a34.png)

