### PR TITLE
fix(home.page): check app version at app launch

### DIFF
--- a/src/app/features/home/home.page.ts
+++ b/src/app/features/home/home.page.ts
@@ -151,8 +151,6 @@ export class HomePage {
   }
 
   private async promptAppUpdateIfAny() {
-    return;
-    // Not applicable to Web App
     if (!this.platform.is('hybrid')) return;
 
     const backendAppInfo = await this.diaBackendService.appInfo$().toPromise();


### PR DESCRIPTION
I accidentally disable the app version check at the app start (during local development). This commit enables app check at app start.