### PR TITLE
Feature: Make iframe URL configurable

### DIFF
--- a/set-secret.js
+++ b/set-secret.js
@@ -8,6 +8,7 @@ const envConfigFile = `
 export const BASE_URL = '${process.env.NUMBERS_STORAGE_BASE_URL}';
 export const TRUSTED_CLIENT_KEY = '${process.env.NUMBERS_STORAGE_TRUSTED_CLIENT_KEY}';
 export const BUBBLE_DB_URL = '${process.env.NUMBERS_BUBBLE_DB_URL}';
+export const BUBBLE_IFRAME_URL = '${process.env.NUMBERS_BUBBLE_IFRAME_URL}';
 export const BUBBLE_API_URL = '${process.env.BUBBLE_API_URL}';
 export const APPS_FLYER_DEV_KEY = '${process.env.APPS_FLYER_DEV_KEY}'
 `;

--- a/src/app/features/home/details/details.page.ts
+++ b/src/app/features/home/details/details.page.ts
@@ -29,6 +29,7 @@ import { ConfirmAlert } from '../../../shared/confirm-alert/confirm-alert.servic
 import { ContactSelectionDialogComponent } from '../../../shared/contact-selection-dialog/contact-selection-dialog.component';
 import { DiaBackendAssetRepository } from '../../../shared/dia-backend/asset/dia-backend-asset-repository.service';
 import { DiaBackendAuthService } from '../../../shared/dia-backend/auth/dia-backend-auth.service';
+import { BUBBLE_IFRAME_URL } from '../../../shared/dia-backend/secret';
 import { DiaBackendWorkflowService } from '../../../shared/dia-backend/workflow/dia-backend-workflow.service';
 import { ErrorService } from '../../../shared/error/error.service';
 import { MediaStore } from '../../../shared/media/media-store/media-store.service';
@@ -183,11 +184,8 @@ export class DetailsPage {
   readonly iframeUrl$ = this.activeDetailedCapture$.pipe(
     distinctUntilChanged(),
     map(detailedCapture => {
-      const host = 'https://captureappiframe.bubbleapps.io';
-      const path = '';
       const params = `pid=${detailedCapture.id}&iframeLoadedFrom=CaptureApp`;
-      // const params = `pid=288036ab-5768-4270-988b-a85d7bd11eb3&iframeLoadedFrom=CaptureApp`;
-      const url = `${host}/${path}?${params}`;
+      const url = `${BUBBLE_IFRAME_URL}/?${params}`;
       return this.sanitizer.bypassSecurityTrustResourceUrl(url);
     })
   );
@@ -209,10 +207,8 @@ export class DetailsPage {
     distinctUntilChanged(),
     map(([detailedCapture]) => {
       const token = this.userToken;
-      const host = 'https://captureappiframe.bubbleapps.io';
-      const path = 'version-qa-release/asset_page';
       const params = `pid=${detailedCapture.id}&token=${token}&iframeLoadedFrom=CaptureApp`;
-      const url = `${host}/${path}?${params}`;
+      const url = `${BUBBLE_IFRAME_URL}/asset_page?${params}`;
       return this.sanitizer.bypassSecurityTrustResourceUrl(url);
     })
   );
@@ -257,7 +253,7 @@ export class DetailsPage {
 
   iframeUrlFor(detailedCapture: any) {
     return this.sanitizer.bypassSecurityTrustResourceUrl(
-      `https://captureappiframe.bubbleapps.io/asset_page?pid=${detailedCapture.id}`
+      `${BUBBLE_IFRAME_URL}/asset_page?pid=${detailedCapture.id}`
     );
   }
 

--- a/src/app/features/home/explore-tab/explore-tab/explore-tab.component.ts
+++ b/src/app/features/home/explore-tab/explore-tab/explore-tab.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { map } from 'rxjs/operators';
 import { DiaBackendAuthService } from '../../../../shared/dia-backend/auth/dia-backend-auth.service';
+import { BUBBLE_IFRAME_URL } from '../../../../shared/dia-backend/secret';
 import { ErrorService } from '../../../../shared/error/error.service';
 import { NetworkService } from '../../../../shared/network/network.service';
 import { isNonNullable } from '../../../../utils/rx-operators/rx-operators';
@@ -15,7 +16,7 @@ export class ExploreTabComponent {
   readonly bubbleIframeUrl$ = this.diaBackendAuthService.token$.pipe(
     isNonNullable(),
     map(token => {
-      return `https://captureappiframe.numbersprotocol.io/version-qa-release/?token=${token}`;
+      return `${BUBBLE_IFRAME_URL}/?token=${token}`;
     })
   );
 


### PR DESCRIPTION
Feature changes
1. Make iframe URL configurable by adding `BUBBLE_IFRAME_URL` in `set-secret.js`.
2. Update the explorer and details pages to use `BUBBLE_IFRAME_URL` instead of the hard-coding URLs.
3. Add repository secret `NUMBERS_BUBBLE_IFRAME_URL`.