### PR TITLE
fix(capture-item): only open capture if uploaded

### DIFF
--- a/src/app/features/home/capture-tab/capture-item/capture-item.component.ts
+++ b/src/app/features/home/capture-tab/capture-item/capture-item.component.ts
@@ -93,12 +93,12 @@ export class CaptureItemComponent {
 
   @HostListener('click')
   onClick() {
-    return this.isCollecting$
+    return this.hasUploaded$
       .pipe(
         first(),
-        switchMap(isCollecting =>
+        switchMap(hasUploaded =>
           iif(
-            () => !isCollecting,
+            () => hasUploaded,
             this.oldProofHash$.pipe(
               first(),
               concatMap(oldProofHash =>

--- a/src/app/features/home/capture-tab/capture-item/capture-item.component.ts
+++ b/src/app/features/home/capture-tab/capture-item/capture-item.component.ts
@@ -1,8 +1,10 @@
 import { Component, HostListener, Input } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
+import { ToastController } from '@ionic/angular';
+import { TranslocoService } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { combineLatest, iif, of, ReplaySubject } from 'rxjs';
+import { combineLatest, of, ReplaySubject } from 'rxjs';
 import {
   catchError,
   concatMap,
@@ -88,32 +90,37 @@ export class CaptureItemComponent {
     private readonly router: Router,
     private readonly route: ActivatedRoute,
     private readonly sanitizer: DomSanitizer,
-    private readonly diaBackendAssetRepository: DiaBackendAssetRepository
+    private readonly diaBackendAssetRepository: DiaBackendAssetRepository,
+    private readonly toastController: ToastController,
+    private readonly translocoService: TranslocoService
   ) {}
 
   @HostListener('click')
-  onClick() {
-    return this.hasUploaded$
-      .pipe(
-        first(),
-        switchMap(hasUploaded =>
-          iif(
-            () => hasUploaded,
-            this.oldProofHash$.pipe(
-              first(),
-              concatMap(oldProofHash =>
-                this.router.navigate(
-                  ['details', { type: 'capture', hash: oldProofHash }],
-                  {
-                    relativeTo: this.route,
-                  }
-                )
-              )
+  async onClick() {
+    const hasUploaded = await this.hasUploaded$.pipe(first()).toPromise();
+    if (hasUploaded) {
+      this.oldProofHash$
+        .pipe(
+          first(),
+          concatMap(oldProofHash =>
+            this.router.navigate(
+              ['details', { type: 'capture', hash: oldProofHash }],
+              { relativeTo: this.route }
             )
-          )
-        ),
-        untilDestroyed(this)
-      )
-      .subscribe();
+          ),
+          untilDestroyed(this)
+        )
+        .subscribe();
+    } else {
+      this.toastController
+        .create({
+          message: this.translocoService.translate(
+            'home.profileTab.captureNotUploadedYet'
+          ),
+          duration: 2000,
+          color: 'primary',
+        })
+        .then(toast => toast.present());
+    }
   }
 }

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -262,7 +262,8 @@
   "home": {
     "profileTab": {
       "captured": "Captured",
-      "collected": "Collected"
+      "collected": "Collected",
+      "captureNotUploadedYet": "Capture not uploaded yet"
     }
   },
   "details": {

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -262,7 +262,8 @@
   "home": {
     "profileTab": {
       "captured": "瞬時影像",
-      "collected": "收藏"
+      "collected": "收藏",
+      "captureNotUploadedYet": "Capture 尚未上傳"
     }
   },
   "details": {


### PR DESCRIPTION
This PR prevents users from opening capture if it's not uploaded yet. Here is the [claap](https://app.claap.io/numbers-protocol/devs-only-open-capture-only-if-uploaded-c-O35CsUM4Uy-NJMagBX76oN_) demo

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203002972154612) by [Unito](https://www.unito.io)
