### PR TITLE
fix tab bar icons load speed

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -114,6 +114,9 @@ export class AppComponent {
       'capture-rebrand-arrow-left',
       'capture-rebrand-share',
       'capture-rebrand-more-horiz',
+      'capture',
+      'profile',
+      'search',
     ];
 
     for (const iconName of captureRebrandedIconNames) {

--- a/src/app/features/home/home.page.html
+++ b/src/app/features/home/home.page.html
@@ -92,13 +92,13 @@
         <mat-tab>
           <ng-template mat-tab-label>
             <button mat-icon-button (click)="navigateToExploreTab()">
-              <ion-icon
-                src="/assets/images/icons/search.svg"
+              <mat-icon
+                svgIcon="search"
                 class="tab-action-button-icon"
                 joyrideStep="highlightHomeTab"
                 title="Home Tab"
                 text="View created captures"
-              ></ion-icon>
+              ></mat-icon>
             </button>
           </ng-template>
           <app-explore-tab></app-explore-tab>
@@ -106,32 +106,30 @@
         <mat-tab disabled>
           <ng-template mat-tab-label>
             <button mat-icon-button (click)="captureWithCustomCamera()">
-              <ion-icon
-                src="/assets/images/icons/capture.svg"
+              <mat-icon
+                svgIcon="capture"
                 class="tab-action-button-icon"
                 joyrideStep="highlightCaptureButton"
                 [title]="t('userGuide.capture')"
                 [text]="
                   t('userGuide.createCapturesByTakingPhotosOrRecordingVideos')
                 "
-              >
-                camera_alt
-              </ion-icon>
+              ></mat-icon>
             </button>
           </ng-template>
         </mat-tab>
         <mat-tab>
           <ng-template mat-tab-label>
             <button mat-icon-button (click)="navigateToInboxTab()">
-              <ion-icon
-                src="/assets/images/icons/profile.svg"
+              <mat-icon
+                svgIcon="profile"
                 class="tab-action-button-icon"
                 joyrideStep="highlightInboxTab"
                 [title]="t('userGuide.inboxTab')"
                 [text]="
                   t('userGuide.visitInboxForPurchasedItemsAndGiftsReceived')
                 "
-              ></ion-icon>
+              ></mat-icon>
             </button>
           </ng-template>
           <app-capture-tab></app-capture-tab>


### PR DESCRIPTION
Before I was loading icons directly from assets path, but after this commit I register icons first then load them. More detailed explanation is available at this [claap](https://app.claap.io/numbers-protocol/devs-q-and-a-only-fixing-tab-icons-c-O35CsUM4Uy-UD_VvzbEJMvV).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203048583466296) by [Unito](https://www.unito.io)
