### PR TITLE
Feature reuse jwt token

### DIFF
--- a/src/app/features/home/details/details.page.ts
+++ b/src/app/features/home/details/details.page.ts
@@ -215,7 +215,7 @@ export class DetailsPage {
 
   readonly iframeUrlWithJWTToken$ = combineLatest([
     this.activeDetailedCapture$,
-    defer(() => this.diaBackendAuthService.queryJWTToken$()),
+    this.diaBackendAuthService.cachedQueryJWTToken$,
   ]).pipe(
     distinctUntilChanged(),
     map(([detailedCapture, token]) => {

--- a/src/app/features/home/explore-tab/explore-tab/explore-tab.component.html
+++ b/src/app/features/home/explore-tab/explore-tab/explore-tab.component.html
@@ -8,11 +8,12 @@
 <ng-template #bubbleIframe>
   <div
     *ngIf="
-      bubbleIframeUrlWithJWTToken$ | ngrxPush as bubbleIframeUrlWithJWTToken
+      bubbleIframeUrlWithCachedJWTToke$
+        | ngrxPush as bubbleIframeUrlWithCachedJWTToken
     "
   >
     <iframe
-      [src]="bubbleIframeUrlWithJWTToken | safeResourceUrl"
+      [src]="bubbleIframeUrlWithCachedJWTToken | safeResourceUrl"
       class="bubble-iframe"
     ></iframe>
   </div>

--- a/src/app/features/home/explore-tab/explore-tab/explore-tab.component.ts
+++ b/src/app/features/home/explore-tab/explore-tab/explore-tab.component.ts
@@ -1,10 +1,7 @@
 import { Component } from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
-import { defer } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { DiaBackendAuthService } from '../../../../shared/dia-backend/auth/dia-backend-auth.service';
 import { BUBBLE_IFRAME_URL } from '../../../../shared/dia-backend/secret';
-import { ErrorService } from '../../../../shared/error/error.service';
 import { NetworkService } from '../../../../shared/network/network.service';
 
 @Component({
@@ -13,20 +10,17 @@ import { NetworkService } from '../../../../shared/network/network.service';
   styleUrls: ['./explore-tab.component.scss'],
 })
 export class ExploreTabComponent {
-  readonly bubbleIframeUrlWithJWTToken$ = defer(() => {
-    return this.diaBackendAuthService.queryJWTToken$().pipe(
+  readonly bubbleIframeUrlWithCachedJWTToke$ =
+    this.diaBackendAuthService.cachedQueryJWTToken$.pipe(
       map(token => {
         return `${BUBBLE_IFRAME_URL}/?token=${token.access}&refresh_token=${token.refresh}`;
       })
     );
-  });
 
   readonly networkConnected$ = this.networkService.connected$;
 
   constructor(
-    private readonly sanitizer: DomSanitizer,
     private readonly networkService: NetworkService,
-    private readonly diaBackendAuthService: DiaBackendAuthService,
-    private readonly errorService: ErrorService
+    private readonly diaBackendAuthService: DiaBackendAuthService
   ) {}
 }

--- a/src/app/utils/date.ts
+++ b/src/app/utils/date.ts
@@ -5,3 +5,9 @@ export function calcDaysBetweenDates(a: Date, b: Date) {
   const diffDays = Math.ceil(diffTime / millisecondsInOneDay);
   return diffDays;
 }
+
+export function secondSince(timestamp: number) {
+  const now = Date.now();
+  const milliseconds = 1000;
+  return Math.ceil((now - timestamp) / milliseconds);
+}


### PR DESCRIPTION
This PR will cache and reuse the Query JWT token. JWT token is valid for 5 minutes but I refresh the token if it's older than 4 minutes so we could have 1 minute in a buffer. Here is the [claap](https://app.claap.io/numbers-protocol/devs-only-reuse-jwt-token-from-cache-c-O35CsUM4Uy-poe6r5p-Gjag) for more details.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203054428002780) by [Unito](https://www.unito.io)
