### PR TITLE
fix(home-page): remove capture club from menu

### DIFF
--- a/src/app/features/home/home.page.html
+++ b/src/app/features/home/home.page.html
@@ -29,11 +29,6 @@
           </a>
         </mat-list-item>
         <mat-list-item>
-          <a (click)="sidenav.close(); openCaptureClub()" mat-list-item>
-            CaptureClub
-          </a>
-        </mat-list-item>
-        <mat-list-item>
           <a routerLink="/invitation" (click)="sidenav.close()" mat-list-item>
             {{ t('invitation.invitation') }}
           </a>


### PR DESCRIPTION
Remove "Capture Club" menu Item from drawer [[screenshot](https://i.imgur.com/lFQkU7J.png)].



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203096968395356) by [Unito](https://www.unito.io)
