### PR TITLE
fix(in-app-store): request num points on wallets page only

### DIFF
--- a/src/app/shared/in-app-store/in-app-store.service.ts
+++ b/src/app/shared/in-app-store/in-app-store.service.ts
@@ -56,7 +56,6 @@ export class InAppStoreService implements OnDestroy {
   async initialize() {
     // Usefull for UI development in WEB environment
     if (!this.isNativePlatform()) {
-      this.refreshNumPointsPricing();
       const mockData = generateMockInAppProducts();
       this.inAppProducts$.next(mockData);
       return;
@@ -64,7 +63,6 @@ export class InAppStoreService implements OnDestroy {
 
     try {
       await this.platform.ready();
-      await this.refreshNumPointsPricing();
 
       this.regiseterStoreListeners();
       this.registerStoreProducts();


### PR DESCRIPTION
Currently, I fetch num points price at app launch. This commit will fetch num points price on the walles page only. Here is the [claap](https://app.claap.io/numbers-protocol/dev-qa-only-fetch-num-point-price-on-wallets-page-open-c-O35CsUM4Uy-BFBipxBsRT8c) for a more detailed explanation.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203147410254210) by [Unito](https://www.unito.io)
