### PR TITLE
fix(capture-tab): remove duplicate network status

### DIFF
--- a/src/app/features/home/capture-tab/capture-tab.component.html
+++ b/src/app/features/home/capture-tab/capture-tab.component.html
@@ -22,10 +22,6 @@
       </ion-segment-button>
     </ion-segment>
 
-    <p *ngIf="(networkConnected$ | ngrxPush) === false" class="network-status">
-      {{ 'message.networkNotConnected' | transloco }}
-    </p>
-
     <div *ngSwitchCase="'captured'">
       <div class="capture-container" *transloco="let t">
         <mat-grid-list cols="2" gutterSize="16px">


### PR DESCRIPTION
A simple fix to remove duplicate network status. Here is the [claap](https://app.claap.io/numbers-protocol/dev-qa-demo-remove-duplicate-network-status-c-O35CsUM4Uy-zG90tZWRc0CY) demo.

NOTE:
Should be included for Oct 25, 2022 (Tuesday) release.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203213127063702) by [Unito](https://www.unito.io)
