### PR TITLE
update @numbersprotocol/preview-camera plugin to version 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5091,8 +5091,8 @@
       }
     },
     "node_modules/@numbersprotocol/preview-camera": {
-      "version": "0.0.8",
-      "resolved": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#b8db8e82a51f8ec574eb41a9c2426a11711d0838",
+      "version": "0.0.9",
+      "resolved": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#a7f11b6c9c34603c14c6ab3c95967dc41522fe8d",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^3.0.0"
@@ -26843,7 +26843,7 @@
       }
     },
     "@numbersprotocol/preview-camera": {
-      "version": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#b8db8e82a51f8ec574eb41a9c2426a11711d0838",
+      "version": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#a7f11b6c9c34603c14c6ab3c95967dc41522fe8d",
       "from": "@numbersprotocol/preview-camera@github:numbersprotocol/preview-camera",
       "requires": {}
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -5091,8 +5091,8 @@
       }
     },
     "node_modules/@numbersprotocol/preview-camera": {
-      "version": "0.0.9",
-      "resolved": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#a7f11b6c9c34603c14c6ab3c95967dc41522fe8d",
+      "version": "0.0.10",
+      "resolved": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#02fbe2931d9c7ba0d171fb919b4a1ae251e9483c",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^3.0.0"
@@ -26843,7 +26843,7 @@
       }
     },
     "@numbersprotocol/preview-camera": {
-      "version": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#a7f11b6c9c34603c14c6ab3c95967dc41522fe8d",
+      "version": "git+ssh://git@github.com/numbersprotocol/preview-camera.git#02fbe2931d9c7ba0d171fb919b4a1ae251e9483c",
       "from": "@numbersprotocol/preview-camera@github:numbersprotocol/preview-camera",
       "requires": {}
     },


### PR DESCRIPTION
Currently, recording video with an iOS front camera will crash the app. To fix an issue I have done some native development.

This PRs from [sultanmyrza](https://github.com/sultanmyrza)/[preview-camera](https://github.com/sultanmyrza/preview-camera) (also synced with [numbersprotocol/preview-camera](https://github.com/numbersprotocol/preview-camera))


* https://github.com/sultanmyrza/preview-camera/pull/16 (version 0.0.9)
* https://github.com/sultanmyrza/preview-camera/pull/17 (version 0.0.10)

will fix the issue iOS camera issue.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203225701370375) by [Unito](https://www.unito.io)

NOTE:
Should be included for Oct 25, 2022 (Tuesday) release.
