### PR TITLE
fix(wallets.page): text from itegrity key to integrity wallet

### DIFF
--- a/src/app/features/wallets/wallets.page.html
+++ b/src/app/features/wallets/wallets.page.html
@@ -102,7 +102,7 @@
     <mat-list-item>
       <mat-icon mat-list-icon>vpn_key</mat-icon>
       <div mat-line>
-        {{ t('wallets.integrityKey') }}
+        {{ t('wallets.integrityWallet') }}
         <ion-icon
           class="info-icon"
           name="information-circle"

--- a/src/assets/i18n/en-us.json
+++ b/src/assets/i18n/en-us.json
@@ -296,7 +296,7 @@
     "integrityWallet": "Integrity Wallet",
     "integrityWalletTooltip": "Wallet used for creating Signatures",
     "viewOnBscScan": "View on BscScan",
-    "exportIntegrityKey": "Export Integrity Key",
+    "exportIntegrityKey": "Export Integrity Wallet",
     "transfer": "Transfer",
     "withdraw": "Withdraw",
     "deposit": "Deposit",

--- a/src/assets/i18n/zh-tw.json
+++ b/src/assets/i18n/zh-tw.json
@@ -304,7 +304,7 @@
     "andIntegrityWallet": "之間移動 NUM",
     "requestSent": "請求已送出",
     "viewOnBscScan": "在 BscScan 上查看",
-    "exportIntegrityKey": "匯出完整性金鑰",
+    "exportIntegrityKey": "匯出完整性錢包",
     "gasFee": "油費",
     "pending": "待計算",
     "total": "總額",


### PR DESCRIPTION
**NOTE:
Should be included for Oct 25, 2022 (Tuesday) release.**

Just change text from "integrity key" to "integrity wallet". Used existing translation.

## Before 
![](https://user-images.githubusercontent.com/12681781/197521886-e6cf2d8c-4050-4070-9c0d-82900a98f5a9.png)

## After
![](https://user-images.githubusercontent.com/12681781/197521693-9ddb6f05-b86c-48d4-922b-4a5ee7261ad1.png)

![](https://user-images.githubusercontent.com/12681781/197521739-ce03f2ef-d20a-47f0-9919-73dae94e9463.png)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203226425089271) by [Unito](https://www.unito.io)
