### PR TITLE
fix(media-store): generate 500x500 thumbnails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Install Ionic CLI
         run: npm install -g @ionic/cli
 
+      - name: Generate .npmrc for pintura package
+        env:
+          NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
+        run: npm run preconfig.npmrc
+
       - name: Install dependencies
         run: npm install
 
@@ -40,6 +45,11 @@ jobs:
 
       - name: Install Ionic CLI
         run: npm install -g @ionic/cli
+
+      - name: Generate .npmrc for pintura package
+        env:
+          NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
+        run: npm run preconfig.npmrc
 
       - name: Install dependencies
         run: npm install

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -374,8 +374,8 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = io.numbersprotocol.capturelite;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV3;
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV3;
+				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV4;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV4;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG USE_PUSH";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -400,8 +400,8 @@
 				MARKETING_VERSION = 0.68.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.numbersprotocol.capturelite;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV3;
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV3;
+				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV4;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV4;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = USE_PUSH;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/src/app/shared/media/media-store/media-store.service.ts
+++ b/src/app/shared/media/media-store/media-store.service.ts
@@ -178,7 +178,7 @@ export class MediaStore {
   }
 
   private async makeThumbnail(index: string, mimeType: MimeType) {
-    const thumbnailSize = 100;
+    const thumbnailSize = 500;
     const thumbnailBlob = mimeType.startsWith('video')
       ? await makeVideoThumbnail({
           videoUrl: await this.getUrl(index, mimeType),
@@ -336,7 +336,7 @@ export const enum OnWriteExistStrategy {
 async function makeImageThumbnail({
   image,
   width,
-  quality = 0.6,
+  quality = 0.8,
 }: {
   image: Blob;
   width: number;


### PR DESCRIPTION
Currently for each capture we generate 100x100 pixels thumbnails. Now we generate 500x500 for clearer picture.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203268406992492) by [Unito](https://www.unito.io)
