### PR TITLE
generate Result URL from capture id

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Install Ionic CLI
         run: npm install -g @ionic/cli
 
+      - name: Generate .npmrc for pintura package
+        env:
+          NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
+        run: npm run preconfig.npmrc
+
       - name: Install dependencies
         run: npm install
 
@@ -40,6 +45,11 @@ jobs:
 
       - name: Install Ionic CLI
         run: npm install -g @ionic/cli
+
+      - name: Generate .npmrc for pintura package
+        env:
+          NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
+        run: npm run preconfig.npmrc
 
       - name: Install dependencies
         run: npm install

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -374,8 +374,8 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = io.numbersprotocol.capturelite;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV3;
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV3;
+				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV4;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV4;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG USE_PUSH";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -400,8 +400,8 @@
 				MARKETING_VERSION = 0.68.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.numbersprotocol.capturelite;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV3;
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV3;
+				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV4;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV4;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = USE_PUSH;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -374,8 +374,8 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = io.numbersprotocol.capturelite;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV4;
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV4;
+				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV3;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV3;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG USE_PUSH";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -400,8 +400,8 @@
 				MARKETING_VERSION = 0.68.0;
 				PRODUCT_BUNDLE_IDENTIFIER = io.numbersprotocol.capturelite;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV4;
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV4;
+				PROVISIONING_PROFILE_SPECIFIER = NumbersAppDistributionV3;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = NumbersAppDistributionV3;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = USE_PUSH;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/src/app/features/home/activities/network-action-order-details/network-action-order-details.page.html
+++ b/src/app/features/home/activities/network-action-order-details/network-action-order-details.page.html
@@ -49,13 +49,18 @@
             <ion-label>{{ t('resultUrl') }}:</ion-label>
           </ion-col>
           <ion-col class="wrap-text" align="end">
-            <ion-label (click)="openResultUrl(order.result_url_text)">
-              <a *ngIf="order.result_url_text !== undefined">
-                {{ order.result_url_text }}
-              </a>
-              <ion-text *ngIf="order.result_url_text === undefined">{{
-                t('noResultUrlAvailable')
-              }}</ion-text>
+            <ion-label
+              *ngIf="order.result_url_text !== undefined"
+              (click)="openResultUrl(order.result_url_text)"
+            >
+              <a> {{ order.result_url_text }} </a>
+            </ion-label>
+
+            <ion-label
+              *ngIf="order.result_url_text === undefined"
+              (click)="openResultUrl(resultUrlFromAssetId(order.asset_id_text))"
+            >
+              <a> {{ resultUrlFromAssetId(order.asset_id_text) }} </a>
             </ion-label>
           </ion-col>
           <ion-col size="1"> </ion-col>

--- a/src/app/features/home/activities/network-action-order-details/network-action-order-details.page.ts
+++ b/src/app/features/home/activities/network-action-order-details/network-action-order-details.page.ts
@@ -9,6 +9,7 @@ import { catchError, first, map } from 'rxjs/operators';
 import { OrderHistoryService } from '../../../../shared/actions/service/order-history.service';
 import { ErrorService } from '../../../../shared/error/error.service';
 import { isNonNullable } from '../../../../utils/rx-operators/rx-operators';
+import { getAssetProfileForCaptureIframe } from '../../../../utils/url';
 
 const { Browser, Clipboard } = Plugins;
 @UntilDestroy({ checkProperties: true })
@@ -42,11 +43,13 @@ export class NetworkActionOrderDetailsPage {
   // eslint-disable-next-line class-methods-use-this
   openResultUrl(url: string) {
     if (url) {
-      Browser.open({
-        url: `${url}`,
-        toolbarColor: '#564dfc',
-      });
+      Browser.open({ url, toolbarColor: '#000000' });
     }
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  resultUrlFromAssetId(assetId: string) {
+    return getAssetProfileForCaptureIframe(assetId);
   }
 
   async copyToClipboard(value: string) {

--- a/src/app/utils/url.ts
+++ b/src/app/utils/url.ts
@@ -1,3 +1,4 @@
+import { BUBBLE_IFRAME_URL } from '../shared/dia-backend/secret';
 import { urlToDownloadApp } from './constants';
 import { MimeType } from './mime-type';
 
@@ -17,6 +18,10 @@ export function getAssetProfileForNSE(id: string, token?: string) {
     return `https://nftsearch.site/asset-profile?cid=${id}&tmp_token=${token}`;
   }
   return `https://nftsearch.site/asset-profile?cid=${id}`;
+}
+
+export function getAssetProfileForCaptureIframe(cid: string) {
+  return `${BUBBLE_IFRAME_URL}/asset_page?nid=${cid}`;
 }
 
 export function getAppDownloadLink(isPlatform: (platformName: any) => boolean) {


### PR DESCRIPTION
NOTE: Should be included in the v221101 release.

This PR will generate the **Result URL** from the capture id. This PR closes 2 task at the same time.

* [✓ Result URL in the network app history should be the URL of Capture asset page](https://app.asana.com/0/1201016280880500/1203129620572131)
* [[issue] Lacking result url for “Share and explore” network action](https://app.asana.com/0/1201016280880500/1202494282094194)

Please see this asana [Comment by @Ethan Wu on Result URL in the network app history should be the URL of Capture asset page](https://app.asana.com/0/0/1203129620572131/1203275644094850/f)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203275787692114) by [Unito](https://www.unito.io)
