### PR TITLE
fix(test.yml): generate npmrc before lint and test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,11 @@ jobs:
       - name: Install Ionic CLI
         run: npm install -g @ionic/cli
 
+      - name: Generate .npmrc for pintura package
+        env:
+          NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
+        run: npm run preconfig.npmrc
+
       - name: Install dependencies
         run: npm install
 
@@ -40,6 +45,11 @@ jobs:
 
       - name: Install Ionic CLI
         run: npm install -g @ionic/cli
+
+      - name: Generate .npmrc for pintura package
+        env:
+          NUMBERS_PQINA_NPM_KEY: ${{ secrets.NUMBERS_PQINA_NPM_KEY }}
+        run: npm run preconfig.npmrc
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
Fix GitHub lint, test jobs (include pintura env key)



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203276431793266) by [Unito](https://www.unito.io)
