### PR TITLE
fix(media-store): generate 500x500 thumbnails

### DIFF
--- a/src/app/shared/media/media-store/media-store.service.ts
+++ b/src/app/shared/media/media-store/media-store.service.ts
@@ -178,7 +178,7 @@ export class MediaStore {
   }
 
   private async makeThumbnail(index: string, mimeType: MimeType) {
-    const thumbnailSize = 100;
+    const thumbnailSize = 500;
     const thumbnailBlob = mimeType.startsWith('video')
       ? await makeVideoThumbnail({
           videoUrl: await this.getUrl(index, mimeType),
@@ -336,7 +336,7 @@ export const enum OnWriteExistStrategy {
 async function makeImageThumbnail({
   image,
   width,
-  quality = 0.6,
+  quality = 0.8,
 }: {
   image: Blob;
   width: number;


### PR DESCRIPTION
**NOTE: Should be included in the v221101 release.**

Currently for each capture we generate 100x100 pixels thumbnails. Now we generate 500x500 for a clearer picture.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203276696292707) by [Unito](https://www.unito.io)
