### PR TITLE
fix GitHub build-ios-prod job

### DIFF
--- a/ios/App/ExportOptions.plist
+++ b/ios/App/ExportOptions.plist
@@ -9,7 +9,7 @@
 	<key>provisioningProfiles</key>
 	<dict>
 		<key>io.numbersprotocol.capturelite</key>
-		<string>NumbersAppDistributionV2</string>
+		<string>NumbersAppDistributionV4</string>
 	</dict>
 	<key>signingCertificate</key>
 	<string>Apple Distribution</string>


### PR DESCRIPTION
Currently, the **build-ios-prod job** is failing with error:

```
error: exportArchive: Provisioning profile "NumbersAppDistributionV2" doesn't include signing certificate "iPhone Distribution: Numbersprotocol Inc. (G7NB5YCKAP)".
```

I found 1 place where we still have `NumbersAppDistributionV2` and change it to `NumbersAppDistributionV4`.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203279753344586) by [Unito](https://www.unito.io)
