### PR TITLE
Fix iframe android back button navigation

### DIFF
--- a/src/app/features/home/explore-tab/explore-tab/explore-tab.component.html
+++ b/src/app/features/home/explore-tab/explore-tab/explore-tab.component.html
@@ -13,6 +13,7 @@
     "
   >
     <iframe
+      #exploreIframe
       [src]="bubbleIframeUrlWithCachedJWTToken"
       class="bubble-iframe"
     ></iframe>

--- a/src/app/features/home/home.page.ts
+++ b/src/app/features/home/home.page.ts
@@ -354,8 +354,7 @@ export class HomePage {
 
   private shouldNavigateBackExploreIframe(): void {
     if (this.selectedTabIndex === 0 && this.router.url === '/home') {
-      // eslint-disable-next-line no-console
-      console.log('TODO: send post message to explore iframe');
+      this.iframeService.navigateBackExploreTabIframe();
     }
   }
 

--- a/src/app/features/home/home.page.ts
+++ b/src/app/features/home/home.page.ts
@@ -20,6 +20,7 @@ import {
   switchMap,
   tap,
 } from 'rxjs/operators';
+import { AndroidBackButtonService } from '../../shared/android-back-button/android-back-button.service';
 import { CameraService } from '../../shared/camera/camera.service';
 import { CaptureService, Media } from '../../shared/capture/capture.service';
 import { ConfirmAlert } from '../../shared/confirm-alert/confirm-alert.service';
@@ -87,7 +88,8 @@ export class HomePage {
     private readonly diaBackendWalletService: DiaBackendWalletService,
     private readonly userGuideService: UserGuideService,
     private readonly platform: Platform,
-    private readonly iframeService: IframeService
+    private readonly iframeService: IframeService,
+    private readonly androidBackButtonService: AndroidBackButtonService
   ) {
     this.downloadExpiredPostCaptures();
   }
@@ -103,6 +105,13 @@ export class HomePage {
           defer(() => this.userGuideService.showUserGuidesOnHomePage())
         ),
         catchError((err: unknown) => this.errorService.toastError$(err)),
+        untilDestroyed(this)
+      )
+      .subscribe();
+
+    this.androidBackButtonService.androidBackButtonEvent$
+      .pipe(
+        tap(_ => this.shouldNavigateBackExploreIframe()),
         untilDestroyed(this)
       )
       .subscribe();
@@ -341,6 +350,13 @@ export class HomePage {
         untilDestroyed(this)
       )
       .subscribe();
+  }
+
+  private shouldNavigateBackExploreIframe(): void {
+    if (this.selectedTabIndex === 0 && this.router.url === '/home') {
+      // eslint-disable-next-line no-console
+      console.log('TODO: send post message to explore iframe');
+    }
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/app/shared/android-back-button/android-back-button.service.ts
+++ b/src/app/shared/android-back-button/android-back-button.service.ts
@@ -7,10 +7,7 @@ import { mapTo, tap } from 'rxjs/operators';
   providedIn: 'root',
 })
 export class AndroidBackButtonService {
-  private readonly androidBackButtonEvent$ = fromEvent(
-    document,
-    'ionBackButton'
-  );
+  readonly androidBackButtonEvent$ = fromEvent(document, 'ionBackButton');
 
   constructor(private readonly zone: NgZone) {}
 

--- a/src/app/shared/iframe/iframe.service.ts
+++ b/src/app/shared/iframe/iframe.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, ReplaySubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -7,7 +7,17 @@ import { BehaviorSubject } from 'rxjs';
 export class IframeService {
   readonly exploreTabRefreshRequested$ = new BehaviorSubject(new Date());
 
+  private readonly _exploreTabIframeNavigateBack$ = new ReplaySubject<boolean>(
+    1
+  );
+  readonly exploreTabIframeNavigateBack$ =
+    this._exploreTabIframeNavigateBack$.asObservable();
+
   refreshExploreTabIframe() {
     this.exploreTabRefreshRequested$.next(new Date());
+  }
+
+  navigateBackExploreTabIframe() {
+    this._exploreTabIframeNavigateBack$.next(true);
   }
 }


### PR DESCRIPTION
**Part of v221115-capture-app-ionic release**

When the android back button is clicked it will navigate back iframe in explore tab. [Claap](https://app.claap.io/numbers-protocol/ionic-iframe-devs-android-back-button-working-for-iframe-c-O35CsUM4Uy-AfmrcRkKrMh4)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203343158313656) by [Unito](https://www.unito.io)
┆Link To Task: https://app.asana.com/0/1201016280880500/1203343158313656
