### PR TITLE
fix(custom-camera): zoom sensitivity

### DIFF
--- a/src/app/features/home/custom-camera/custom-camera.service.ts
+++ b/src/app/features/home/custom-camera/custom-camera.service.ts
@@ -133,7 +133,12 @@ export class CustomCameraService {
   async maxZoomFactor(): Promise<number> {
     const defaultMaxAvailableZoom = 0;
     if (this.isNativePlatform) {
-      return (await PreviewCamera.maxAvailableZoom()).result;
+      let maxZoomFactor = (await PreviewCamera.maxAvailableZoom()).result;
+      const sensitivityFactor = 4;
+      if (maxZoomFactor > 0) {
+        maxZoomFactor /= sensitivityFactor;
+      }
+      return maxZoomFactor;
     }
     return Promise.resolve(defaultMaxAvailableZoom);
   }


### PR DESCRIPTION
**Part of release v221129-capture-app-ionic**

Before camera zoom was too sensitive (moving zoom slider zooms in too fast and too far). 

Here are the fixed [iOS](https://i.imgur.com/eQ01XKv.mp4) and [Android](https://i.imgur.com/Xuw1npx.mp4) demos.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203404264659297) by [Unito](https://www.unito.io)
