### PR TITLE
fix: custom camera back button nav via angular router

### DIFF
--- a/src/app/features/home/custom-camera/custom-camera.page.ts
+++ b/src/app/features/home/custom-camera/custom-camera.page.ts
@@ -242,7 +242,7 @@ export class CustomCameraPage implements OnInit, OnDestroy {
   }
 
   async leaveCustomCamera() {
-    return this.location.back();
+    this.router.navigate(['..']);
   }
 
   async captureFromGoPro() {

--- a/src/app/features/home/custom-camera/custom-camera.page.ts
+++ b/src/app/features/home/custom-camera/custom-camera.page.ts
@@ -3,7 +3,7 @@ import { Location } from '@angular/common';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Capacitor, PluginListenerHandle } from '@capacitor/core';
-import { NavController, Platform } from '@ionic/angular';
+import { Platform } from '@ionic/angular';
 import { UntilDestroy } from '@ngneat/until-destroy';
 import { CaptureResult, PreviewCamera } from '@numbersprotocol/preview-camera';
 import { BehaviorSubject, Subscription } from 'rxjs';
@@ -68,8 +68,7 @@ export class CustomCameraPage implements OnInit, OnDestroy {
     private readonly goProBluetoothService: GoProBluetoothService,
     private readonly errorService: ErrorService,
     private readonly userGuideService: UserGuideService,
-    private readonly platform: Platform,
-    private readonly navCtrl: NavController
+    private readonly platform: Platform
   ) {}
 
   ngOnInit() {
@@ -99,7 +98,7 @@ export class CustomCameraPage implements OnInit, OnDestroy {
         if (this.mode$.value === 'pre-publish') {
           this.discardCurrentCapture();
         } else {
-          this.navCtrl.back();
+          this.leaveCustomCamera();
         }
       });
   }


### PR DESCRIPTION
**Part of v221129-capture-app-ionic**

Before we were using `this.location.back();` to navigate back which works fine on iOS and Android. However, the QA reported that Pixel 6a use can not navigate back.

I was able to reproduce the issue and tried 3 versions to navigate back
- `this.navCtrl.back();` using NavController from "ionic/angular"
- `this.location.back();`
- `this.router.navigate(['..'])` worked on Android 6a

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203425374552216) by [Unito](https://www.unito.io)
