### PR TITLE
fix(network-action-order-details.page): result url redirects to asset…

### DIFF
--- a/src/app/features/home/activities/network-action-order-details/network-action-order-details.page.ts
+++ b/src/app/features/home/activities/network-action-order-details/network-action-order-details.page.ts
@@ -9,7 +9,7 @@ import { catchError, first, map } from 'rxjs/operators';
 import { OrderHistoryService } from '../../../../shared/actions/service/order-history.service';
 import { ErrorService } from '../../../../shared/error/error.service';
 import { isNonNullable } from '../../../../utils/rx-operators/rx-operators';
-import { getAssetProfileForCaptureIframe } from '../../../../utils/url';
+import { getAssetProfileForNSE } from '../../../../utils/url';
 
 const { Browser, Clipboard } = Plugins;
 @UntilDestroy({ checkProperties: true })
@@ -49,7 +49,7 @@ export class NetworkActionOrderDetailsPage {
 
   // eslint-disable-next-line class-methods-use-this
   resultUrlFromAssetId(assetId: string) {
-    return getAssetProfileForCaptureIframe(assetId);
+    return getAssetProfileForNSE(assetId);
   }
 
   async copyToClipboard(value: string) {


### PR DESCRIPTION
**Part of v221125-capture-app-ionic**

fix for [[FR] When the prod is unpublish, the NUM price should be turn back to "UNLIST"](https://app.asana.com/0/1203248692432071/1203432297684037/f) asana task.



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203437231580154) by [Unito](https://www.unito.io)
