### PR TITLE
fix(media-store): only ignore File Not Exist error

### DIFF
--- a/src/app/shared/media/media-store/media-store.service.ts
+++ b/src/app/shared/media/media-store/media-store.service.ts
@@ -133,13 +133,15 @@ export class MediaStore {
           path: `${this.rootDir}/${index}.${extension}`,
         });
       } catch (error: any) {
-        // In capture app we get "File does not exist error"
-        // if currentPlatform.isAndroid() === true &&
-        //    fileToBeDeleted.isCapturedFromIphone() === true
-        // When we delete capture from iPhone that was captured
-        // by Android "File does not exists" is not thrown.
-        // So we can silently ignore "File does not exist" error
-        // while deleting capture from FileSystem only.
+        /* WORKAROUND
+         * In capture app we get "File does not exist error"
+         * if currentPlatform.isAndroid() === true &&
+         *    fileToBeDeleted.isCapturedFromIphone() === true
+         * When we delete capture from iPhone that was captured
+         * by Android "File does not exists" is not thrown.
+         * So we can silently ignore "File does not exist" error
+         * while deleting capture from FileSystem only.
+         */
         if (error.message !== 'File does not exist') {
           throw error;
         }


### PR DESCRIPTION
**Part of v221125-capture-app-ionic**

Fix for [[FR] Allow users to archive assets from Capture App](https://app.asana.com/0/1201016280880500/1202798342707582/f) here is the [claap](https://app.claap.io/numbers-protocol/capture-delete-issue-fix-c-O35CsUM4Uy-g_X7fb0BAynA) explanation



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203438012082188) by [Unito](https://www.unito.io)
