### PR TITLE
fix(capacitor.config): run Capacitor web server under https on Android

### DIFF
--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -17,5 +17,8 @@
       "iconColor": "#564dfc"
     }
   },
-  "cordova": {}
+  "cordova": {},
+  "server": {
+    "androidScheme": "https"
+  }
 }


### PR DESCRIPTION
@bafu can we add this PR for tomorrow's release? Here is the [claap](https://app.claap.io/numbers-protocol/run-the-capacitor-web-server-on-android-under-https-c-O35CsUM4Uy-xIuEAf4lu7yS) explanation.

P.S: I set autogenerated task as a dependency for this task [[issue] Capture app doesn't allow Pixel6A user to confirm to register photos.
](https://app.asana.com/0/1201016280880500/1203175716103883/f)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203449413499957) by [Unito](https://www.unito.io)
