### PR TITLE
fix(custom-camera.service): show exact error message

### DIFF
--- a/src/app/features/home/custom-camera/custom-camera.service.ts
+++ b/src/app/features/home/custom-camera/custom-camera.service.ts
@@ -59,9 +59,8 @@ export class CustomCameraService {
       const mimeType = itemToUpload.mimeType;
       await this.captureService.capture({ base64, mimeType });
       await this.removeFile(filePath);
-    } catch (error) {
-      const errMsg = this.translocoService.translate(`error.internetError`);
-      await this.errorService.toastError$(errMsg).toPromise();
+    } catch (error: any) {
+      await this.errorService.toastError$(error.message).toPromise();
     }
   }
 


### PR DESCRIPTION
**Part of v221129-capture-app-ionic**

I want to show the exact error message during the capture upload. If QA sees an exact error in production we catch it and next release convert it to a more user-friendly message. But at this point, I'm not sure what type of error might occur. One of the is "digest" undefined which happens on Pixel A6.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203454980354247) by [Unito](https://www.unito.io)
