### PR TITLE
fix(custom-camera.page): rename "STORY" to "SHORT"

### DIFF
--- a/src/app/features/home/custom-camera/custom-camera.page.html
+++ b/src/app/features/home/custom-camera/custom-camera.page.html
@@ -84,7 +84,7 @@
             [ngClass]="{ selected: isStoryMode$ | ngrxPush }"
             (click)="selectMode('story')"
           >
-            STORY
+            SHORT
           </div>
           <div
             class="camera-mode-item"


### PR DESCRIPTION
Hot fix to rename Story to Short in the custom camera page. Based on this slack [conversation](https://dt42-numbers.slack.com/archives/C43K663U0/p1671616022903489?thread_ts=1671612590.719659&cid=C43K663U0).

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203593763476394) by [Unito](https://www.unito.io)
