### PR TITLE
fix: custom-camera header, footer size

### DIFF
--- a/src/app/features/home/custom-camera/custom-camera.page.scss
+++ b/src/app/features/home/custom-camera/custom-camera.page.scss
@@ -1,6 +1,6 @@
-$camera-header-height: calc(86px - env(safe-area-inset-top));
-$camera-zoom-slider-height: calc(58px - env(safe-area-inset-bottom));
-$camera-footer-height: calc(168px - env(safe-area-inset-bottom));
+$camera-header-height: calc(64px);
+$camera-zoom-slider-height: calc(58px);
+$camera-footer-height: calc(168px);
 $camera-preview-height: calc(
   100% - #{$camera-header-height} - #{$camera-zoom-slider-height} - #{$camera-footer-height}
 );


### PR DESCRIPTION
Some iOS devices have a display cutouts, this PR should fix it.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203601326768392) by [Unito](https://www.unito.io)
