### PR TITLE
fix(transfer.page): change qr code text color to white

### DIFF
--- a/src/app/features/wallets/transfer/transfer.page.scss
+++ b/src/app/features/wallets/transfer/transfer.page.scss
@@ -177,6 +177,7 @@ ion-card {
 }
 
 .asset-wallet-qr-code-container {
+  color: white !important; /* stylelint-disable-line declaration-no-important */
   max-width: 300px;
   margin: 0 auto;
   display: flex;


### PR DESCRIPTION
After applying white flash fix, some UI element colors are black.
One example was on android wallet page, card was black.

This is fix for transfer page text that become black. To fix it I manually set it to white.