### PR TITLE
fix(wallet.page): align mainnet row items center

### DIFF
--- a/src/app/features/wallets/wallets.page.scss
+++ b/src/app/features/wallets/wallets.page.scss
@@ -65,6 +65,7 @@ ion-card {
     #mainnet-points-row {
       margin-top: 5%;
       padding-left: 2%;
+      align-items: center;
 
       .mainnet-points {
         letter-spacing: 0.05em;


### PR DESCRIPTION
I set vertical alignment to the center. [demo](https://i.imgur.com/kr4GUdA.mp4)