### PR TITLE
fix: CI deprecated github commands

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Get release version
         id: version_check
-        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+        run: echo "version_new=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Build Ionic
         env:
@@ -90,7 +90,7 @@ jobs:
 
       - name: Get release version
         id: version_check
-        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+        run: echo "version_new=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Build Ionic
         env:
@@ -166,7 +166,7 @@ jobs:
 
       - name: Get release version
         id: version_check
-        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+        run: echo "version_new=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Build Ionic
         env:
@@ -286,7 +286,7 @@ jobs:
 
       - name: Get release version
         id: version_check
-        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\//}
+        run: echo "version_new=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Create GitHub prerelease
         id: create_release


### PR DESCRIPTION
Inspired by this [post](https://hynek.me/til/set-output-deprecation-github-actions/). Tested on a [experiment](https://github.com/sultanmyrza/experiments-github-actions/blob/90ad31de085373066b1a06b373491e4c8a2c56fb/.github/workflows/sample.yml#L36) repo. Quick [claap](https://app.claap.io/numbers-protocol/bafu-or-tammy-update-capture-ci-scripts-for-git-hub-change-c-O35CsUM4Uy-Z-ruanoAoqZw) explanation.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1203850410258552) by [Unito](https://www.unito.io)
