### PR TITLE
ci(build-apks.yml): use rclone to upload apks to Google Drive

### DIFF
--- a/.github/workflows/build-apks.yml
+++ b/.github/workflows/build-apks.yml
@@ -40,6 +40,15 @@ jobs:
           diff-search: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup rclone
+        env:
+          RCLONE_CONFIG_BASE64: ${{ secrets.RCLONE_CONFIG_BASE64 }}
+        run: |
+          curl https://rclone.org/install.sh | sudo bash
+          mkdir -p ~/.config/rclone
+          echo -n "$RCLONE_CONFIG_BASE64" | base64 -d > ~/.config/rclone/rclone.conf
+          rclone lsd gdrive:/
+
       - name: Build Ionic
         env:
           NUMBERS_STORAGE_BASE_URL: ${{ secrets[matrix.storage_base_url] }}
@@ -63,10 +72,5 @@ jobs:
           ./gradlew assembleDebug
 
       - name: Upload matrix build outputs to Google Drive
-        uses: numbersprotocol/action-google-drive@master
-        with:
-          skicka-tokencache-json: ${{ secrets.SKICKA_TOKENCACHE_JSON }}
-          google-client-id: ${{ secrets.SKICKA_GOOGLE_CLIENT_ID }}
-          google-client-secret: ${{ secrets.SKICKA_GOOGLE_CLIENT_SECRET }}
-          upload-from: ./android/app/build/outputs/apk/debug/
-          upload-to: /capture-lite/apk/${{github.ref_name}}/${{ matrix.folder_name }}/
+        run: |
+          rclone copy ./android/app/build/outputs/apk/debug/ gdrive:/${{github.ref_name}}/${{ matrix.folder_name }}/


### PR DESCRIPTION
## CI/CD
- Replace unmaintained Skicka package with rclone to upload APKs to Google Drive

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1204925844466679) by [Unito](https://www.unito.io)
