### PR TITLE
Fix v230711 issue User can’t register asset when using capture camera

### DIFF
--- a/src/app/features/home/custom-camera/custom-camera.page.html
+++ b/src/app/features/home/custom-camera/custom-camera.page.html
@@ -150,6 +150,7 @@
     *ngIf="(mode$ | ngrxPush) === 'pre-publish'"
     [curCaptureFileSize]="curCaptureFileSize"
     [curCaptureFilePath]="curCaptureFilePath"
+    [curCaptureFileName]="curCaptureFileName"
     [curCaptureMimeType]="curCaptureMimeType"
     [curCaptureSrc]="curCaptureSrc"
     (confirm)="confirmCurrentCapture()"

--- a/src/app/features/home/custom-camera/custom-camera.page.ts
+++ b/src/app/features/home/custom-camera/custom-camera.page.ts
@@ -79,6 +79,7 @@ export class CustomCameraPage implements OnInit, OnDestroy {
 
   curCaptureFileSize?: number;
   curCaptureFilePath?: string;
+  curCaptureFileName?: string;
   curCaptureMimeType?: 'image/jpeg' | 'video/mp4';
   curCaptureType?: MediaType = 'image';
   curCaptureSrc?: string;
@@ -137,8 +138,32 @@ export class CustomCameraPage implements OnInit, OnDestroy {
     });
   }
 
-  private handleCaptureSuccessResult(result: CaptureSuccessResult) {
-    this.prepareForPublishing(result, CameraSource.Camera);
+  private async handleCaptureSuccessResult(result: CaptureSuccessResult) {
+    const resultCopy = await this.copyResultIfNeeded(result);
+    this.prepareForPublishing(resultCopy, CameraSource.Camera);
+  }
+
+  private async copyResultIfNeeded(result: CaptureSuccessResult) {
+    /**
+     * WORKAROUND: https://github.com/numbersprotocol/capture-lite/issues/2904
+     * On Android 13 capacitor filesystem plugin need to pass directory parameter to be
+     * able to re-write media file (aka when we edit image and save it the same file).
+     * Therefore we copy image to cache so we can re-write it if user crop/filter the image.
+     *
+     */
+    if (this.platform.is('android') && result.mimeType.startsWith('image/')) {
+      const originalFilePath = result.path;
+      const readFileResult = await Filesystem.readFile({ path: result.path });
+      const writeFileResult = await Filesystem.writeFile({
+        data: readFileResult.data,
+        path: `${result.name}`,
+        directory: Directory.Cache,
+        recursive: true,
+      });
+      result.path = writeFileResult.uri;
+      await Filesystem.deleteFile({ path: originalFilePath });
+    }
+    return result;
   }
 
   private handleCaptureErrorResult(result: CaptureErrorResult) {
@@ -151,6 +176,7 @@ export class CustomCameraPage implements OnInit, OnDestroy {
   ) {
     this.curCaptureFileSize = result.size;
     this.curCaptureFilePath = result.path;
+    this.curCaptureFileName = result.name;
     this.curCaptureMimeType = result.mimeType;
     this.curCaptureType = result.mimeType === 'image/jpeg' ? 'image' : 'video';
     this.curCaptureSrc = Capacitor.convertFileSrc(result.path);
@@ -323,7 +349,7 @@ export class CustomCameraPage implements OnInit, OnDestroy {
       const readFileResult = await Filesystem.readFile({ path: file.path });
       const writeFileresult = await Filesystem.writeFile({
         data: readFileResult.data,
-        path: `${Date.now()}/${file.name}`,
+        path: `${file.name}`,
         directory: Directory.Cache,
         recursive: true,
       });

--- a/src/app/features/home/custom-camera/pre-publish-mode/pre-publish-mode.component.ts
+++ b/src/app/features/home/custom-camera/pre-publish-mode/pre-publish-mode.component.ts
@@ -7,8 +7,8 @@ import {
   Output,
   ViewChild,
 } from '@angular/core';
-import { FilesystemPlugin } from '@capacitor/filesystem';
-import { AlertController } from '@ionic/angular';
+import { Directory, FilesystemPlugin } from '@capacitor/filesystem';
+import { AlertController, Platform } from '@ionic/angular';
 import { TranslocoService } from '@ngneat/transloco';
 import { ColorMatrix, getEditorDefaults } from '@pqina/pintura';
 import {
@@ -62,6 +62,8 @@ export class PrePublishModeComponent {
 
   readonly curCaptureFilePath$ = new ReplaySubject<string>(1);
 
+  readonly curCaptureFileName$ = new ReplaySubject<string>(1);
+
   readonly curCaptureMimeType$ = new ReplaySubject<CaptureMimeType>(1);
 
   readonly curCaptureSrc$ = new ReplaySubject<string>(1);
@@ -109,6 +111,11 @@ export class PrePublishModeComponent {
   }
 
   @Input()
+  set curCaptureFileName(value: string | undefined) {
+    if (value) this.curCaptureFileName$.next(value);
+  }
+
+  @Input()
   set curCaptureMimeType(value: CaptureMimeType | undefined) {
     if (value) this.curCaptureMimeType$.next(value);
   }
@@ -129,7 +136,8 @@ export class PrePublishModeComponent {
     private readonly filesystemPlugin: FilesystemPlugin,
     private readonly errorService: ErrorService,
     private readonly alertController: AlertController,
-    private readonly translocoService: TranslocoService
+    private readonly translocoService: TranslocoService,
+    private readonly platform: Platform
   ) {}
 
   handleEditorUpdate(imageState: any): void {
@@ -150,12 +158,24 @@ export class PrePublishModeComponent {
 
   async handleEditorProcess(imageWriterResult: any): Promise<void> {
     const base64 = await blobToBase64(imageWriterResult.dest as File);
-    combineLatest([this.curCaptureFilePath$, of(base64)])
+    combineLatest([
+      this.curCaptureFilePath$,
+      of(base64),
+      this.isImage$,
+      this.curCaptureFileName$,
+    ])
       .pipe(
         first(),
-        switchMap(([path, data]) =>
-          this.filesystemPlugin.writeFile({ path, data })
-        ),
+        switchMap(([path, data, isImage, fileName]) => {
+          if (this.platform.is('android') && isImage) {
+            return this.filesystemPlugin.writeFile({
+              path: fileName,
+              data: data,
+              directory: Directory.Cache,
+            });
+          }
+          return this.filesystemPlugin.writeFile({ path, data });
+        }),
         tap(() => this.isProcessingImage$.next(false)),
         tap(() => this.confirm.emit(true)),
         catchError((error: unknown) => {


### PR DESCRIPTION
Fixes https://app.asana.com/0/1201083422707776/1205042457187289/f 

On androd 13 we need to copy temporarely copy image to cache as explained in WORKAROUND: https://github.com/numbersprotocol/capture-lite/issues/2904

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1205122623750227) by [Unito](https://www.unito.io)
