### PR TITLE
fix(signup.page): show correct error message for duplicate username

### DIFF
--- a/src/app/features/signup/signup.page.ts
+++ b/src/app/features/signup/signup.page.ts
@@ -242,7 +242,7 @@ export class SignupPage {
     }
     if (
       err instanceof HttpErrorResponse &&
-      err.error.error?.details?.username?.length > 0
+      err.error.error?.type === 'duplicate_username'
     ) {
       return this.errorService.toastError$(
         this.translocoService.translate('error.diaBackend.duplicate_username')


### PR DESCRIPTION
Fixes [[Issue] When user registers the account but user inputs the existing name, the error message is wrong.](https://app.asana.com/0/1201016280880500/1204125871819015/f)

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1205841758848774) by [Unito](https://www.unito.io)
