### PR TITLE
feat: Add the API key to the header in the API that creates an asset …

### DIFF
--- a/src/app/shared/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/shared/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -216,7 +216,7 @@ export class DiaBackendAssetRepository {
 
   addCapture$(proof: Proof) {
     return forkJoin([
-      defer(() => this.authService.getAuthHeaders()),
+      defer(() => this.authService.getAuthHeadersWithApiKey()),
       defer(() => buildFormDataToCreateAsset(proof)),
     ]).pipe(
       concatMap(([headers, formData]) =>


### PR DESCRIPTION
closes #3036, here is the [Comment by @Sam on Capture Cam - Add the API key to the header in the API that creates an asset to record the service_name of assets.](https://app.asana.com/0/0/1205566659531088/1205811735733240/f).



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1206055293711679) by [Unito](https://www.unito.io)
