### PR TITLE
chore: Update VSCode formatting settings.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,9 +2,9 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true,
-    "source.organizeImports": true
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.stylelint": "explicit",
+    "source.organizeImports": "explicit"
   },
   "typescript.preferences.importModuleSpecifier": "relative"
 }


### PR DESCRIPTION
On every launch VSCode keep changin codeActionsOnSave from true to `explicit`. Turns out, VSCode true is set to `explicit` since VSCode 1.85.0. It seems boolean values were supported until 1.84.0. https://stackoverflow.com/a/77637765

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201016280880500/1206640289167437) by [Unito](https://www.unito.io)
