### PR TITLE
feat(app/utils/url.ts): update asset profile url

### DIFF
--- a/src/app/features/home/details/capture-details-with-ionic/capture-details-with-ionic.component.ts
+++ b/src/app/features/home/details/capture-details-with-ionic/capture-details-with-ionic.component.ts
@@ -27,7 +27,6 @@ export class CaptureDetailsWithIonicComponent {
   captionOn = true;
 
   readonly detailedCapture$ = new ReplaySubject<DetailedCapture>(1);
-  readonly detailedCaptureTmpShareToken$ = new ReplaySubject<string>(1);
   readonly thumbnailUrl$ = this.detailedCapture$.pipe(
     switchMap(capture => capture.proof$),
     isNonNullable(),
@@ -68,11 +67,6 @@ export class CaptureDetailsWithIonicComponent {
     if (value) this.detailedCapture$.next(value);
   }
 
-  @Input()
-  set detailedCaptureTmpShareToken(value: string | undefined) {
-    if (value) this.detailedCaptureTmpShareToken$.next(value);
-  }
-
   constructor(
     private readonly translocoService: TranslocoService,
     private readonly datePipe: DatePipe,
@@ -100,16 +94,15 @@ export class CaptureDetailsWithIonicComponent {
   }
 
   openCertificate() {
-    combineLatest([this.detailedCapture$, this.detailedCaptureTmpShareToken$])
+    combineLatest([this.detailedCapture$])
       .pipe(
         first(),
-        concatMap(([detailedCapture, tmpShareToken]) =>
+        concatMap(([detailedCapture]) =>
           defer(() =>
             Browser.open({
               url: getAssetProfileForNSE(
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                detailedCapture.id!,
-                tmpShareToken
+                detailedCapture.id!
               ),
               toolbarColor: '#564dfc',
             })

--- a/src/app/utils/url.ts
+++ b/src/app/utils/url.ts
@@ -6,11 +6,8 @@ export function toDataUrl(base64: string, mimeType: MimeType | string) {
   return `data:${mimeType};base64,${base64}`;
 }
 
-export function getAssetProfileForNSE(id: string, token?: string) {
-  if (token) {
-    return `https://verify.numbersprotocol.io/asset-profile?nid=${id}&tmp_token=${token}`;
-  }
-  return `https://verify.numbersprotocol.io/asset-profile?nid=${id}`;
+export function getAssetProfileForNSE(id: string) {
+  return `https://verify.numbersprotocol.io/asset-profile/${id}`;
 }
 
 export function getAssetProfileForCaptureIframe(cid: string) {


### PR DESCRIPTION
### Changed

1. Update the URL format of the asset profile from
`/asset-profile?nid=${nid}` to `/asset-profile/${nid}` [#3242](https://github.com/numbersprotocol/capture-lite/pull/3242)
1. Remove the unused `tmp_token` from the asset profile URL  [#3242](https://github.com/numbersprotocol/capture-lite/pull/3242)

​
┆The issue is also created on [Asana](https://app.asana.com/0/1201016280880500/1207136050658172)