### PR TITLE
fix(shared/dia-backend/asset): prefetch error

### DIFF
--- a/ios/App/PrivacyInfo.xcprivacy
+++ b/ios/App/PrivacyInfo.xcprivacy
@@ -1,17 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict>
-			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
-			<key>NSPrivacyAccessedAPITypeReasons</key>
-			<array>
-				<string>C617.1</string>
-			</array>
-		</dict>
-	</array>
-</dict>
+  <dict>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>C617.1</string>
+        </array>
+      </dict>
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>CA92.1</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
 </plist>

--- a/src/app/shared/dia-backend/asset/downloading/dia-backend-downloading.service.ts
+++ b/src/app/shared/dia-backend/asset/downloading/dia-backend-downloading.service.ts
@@ -9,7 +9,7 @@ import {
   getSignatures,
   getTruth,
 } from '../../../repositories/proof/old-proof-adapter';
-import { Proof } from '../../../repositories/proof/proof';
+import { Proof, Truth } from '../../../repositories/proof/proof';
 import { ProofRepository } from '../../../repositories/proof/proof-repository.service';
 import {
   DiaBackendAsset,
@@ -66,12 +66,19 @@ export class DiaBackendAssetDownloadingService {
     ) {
       return;
     }
-    const proof = new Proof(
-      this.mediaStore,
-      getTruth({
+    let truth: Truth;
+    try {
+      truth = getTruth({
         proof: diaBackendAsset.information.proof,
         information: diaBackendAsset.information.information,
-      }),
+      });
+    } catch {
+      return; // Skip storing proof without truth
+    }
+
+    const proof = new Proof(
+      this.mediaStore,
+      truth,
       getSignatures(diaBackendAsset.signature)
     );
     proof.setIndexedAssets({


### PR DESCRIPTION
### Fixed
1. Fix prefetch error caused by incorrect asset information format [#3245](https://github.com/numbersprotocol/capture-lite/pull/3245)

​
┆The issue is also created on [Asana](https://app.asana.com/0/1201016280880500/1207310852515876)