### PR TITLE
feat(features/home): link asset profile to parent

### DIFF
--- a/src/app/features/home/activities/network-action-order-details/network-action-order-details.page.ts
+++ b/src/app/features/home/activities/network-action-order-details/network-action-order-details.page.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
-import { Plugins } from '@capacitor/core';
+import { Clipboard } from '@capacitor/clipboard';
 import { NavController } from '@ionic/angular';
 import { TranslocoService } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
@@ -21,9 +21,7 @@ import { ErrorService } from '../../../../shared/error/error.service';
 import { BubbleToIonicPostMessage } from '../../../../shared/iframe/iframe';
 import { NetworkService } from '../../../../shared/network/network.service';
 import { isNonNullable } from '../../../../utils/rx-operators/rx-operators';
-import { getAssetProfileForNSE } from '../../../../utils/url';
 
-const { Browser, Clipboard } = Plugins;
 @UntilDestroy({ checkProperties: true })
 @Component({
   selector: 'app-network-action-order-details',
@@ -123,18 +121,6 @@ export class NetworkActionOrderDetailsPage {
         concatMap(orderId => this.copyToClipboard(orderId))
       )
       .subscribe();
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  openResultUrl(url: string) {
-    if (url) {
-      Browser.open({ url, toolbarColor: '#000000' });
-    }
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  resultUrlFromAssetId(assetId: string) {
-    return getAssetProfileForNSE(assetId);
   }
 
   async copyToClipboard(value: string) {

--- a/src/app/features/home/details/capture-details-with-ionic/capture-details-with-ionic.component.ts
+++ b/src/app/features/home/details/capture-details-with-ionic/capture-details-with-ionic.component.ts
@@ -103,7 +103,7 @@ export class CaptureDetailsWithIonicComponent {
             Browser.open({
               url: getAssetProfileForNSE(
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                detailedCapture.id!
+                detailedCapture.parentAssetCid || detailedCapture.id!
               ),
               toolbarColor: browserToolbarColor,
             })

--- a/src/app/features/home/details/capture-details-with-ionic/capture-details-with-ionic.component.ts
+++ b/src/app/features/home/details/capture-details-with-ionic/capture-details-with-ionic.component.ts
@@ -102,7 +102,10 @@ export class CaptureDetailsWithIonicComponent {
           defer(() =>
             Browser.open({
               url: getAssetProfileForNSE(
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                /* eslint-disable-next-line
+                  @typescript-eslint/no-non-null-assertion,
+                  @typescript-eslint/prefer-nullish-coalescing
+                */
                 detailedCapture.parentAssetCid || detailedCapture.id!
               ),
               toolbarColor: browserToolbarColor,

--- a/src/app/features/home/details/details.page.ts
+++ b/src/app/features/home/details/details.page.ts
@@ -392,7 +392,9 @@ export class DetailsPage {
                 buttons.push({
                   text: viewProofText,
                   handler: async () => {
-                    await this.handleOpenProofAction(diaBackendAsset.id);
+                    await this.handleOpenProofAction(
+                      diaBackendAsset.parent_asset_cid || diaBackendAsset.id
+                    );
                     resolve();
                   },
                 });

--- a/src/app/features/home/details/information/session/information-session.service.ts
+++ b/src/app/features/home/details/information/session/information-session.service.ts
@@ -45,6 +45,11 @@ export class DetailedCapture {
       ? getOldProof(this.proofOrDiaBackendAsset).hash
       : this.proofOrDiaBackendAsset.proof_hash;
 
+  readonly parentAssetCid =
+    this.proofOrDiaBackendAsset instanceof Proof
+      ? this.proofOrDiaBackendAsset.parentAssetCid
+      : this.proofOrDiaBackendAsset.parent_asset_cid;
+
   readonly mediaUrl$ = defer(() => {
     if (this.proofOrDiaBackendAsset instanceof Proof) {
       const proof = this.proofOrDiaBackendAsset;

--- a/src/app/shared/dia-backend/asset/dia-backend-asset-repository.service.ts
+++ b/src/app/shared/dia-backend/asset/dia-backend-asset-repository.service.ts
@@ -355,6 +355,7 @@ export interface DiaBackendAsset extends Tuple {
   readonly mint_workflow_id: string;
   readonly uploaded_at: string;
   readonly public_access: boolean;
+  readonly parent_asset_cid: string;
 }
 
 export interface OwnerAddresses extends Tuple {

--- a/src/app/shared/dia-backend/asset/downloading/dia-backend-downloading.service.ts
+++ b/src/app/shared/dia-backend/asset/downloading/dia-backend-downloading.service.ts
@@ -89,6 +89,7 @@ export class DiaBackendAssetDownloadingService {
     proof.diaBackendAssetId = diaBackendAsset.id;
     proof.caption = diaBackendAsset.caption;
     proof.uploadedAt = diaBackendAsset.uploaded_at;
+    proof.parentAssetCid = diaBackendAsset.parent_asset_cid;
     if (diaBackendAsset.signed_metadata) proof.setSignatureVersion();
     return this.proofRepository.add(proof, OnConflictStrategy.REPLACE);
   }

--- a/src/app/shared/dia-backend/asset/uploading/dia-backend-asset-uploading.service.ts
+++ b/src/app/shared/dia-backend/asset/uploading/dia-backend-asset-uploading.service.ts
@@ -146,6 +146,7 @@ export class DiaBackendAssetUploadingService {
       map(diaBackendAsset => {
         proof.diaBackendAssetId = diaBackendAsset.id;
         proof.uploadedAt = diaBackendAsset.uploaded_at;
+        proof.parentAssetCid = diaBackendAsset.parent_asset_cid;
         return proof;
       }),
       retryWhen(err$ =>

--- a/src/app/shared/repositories/proof/proof.ts
+++ b/src/app/shared/repositories/proof/proof.ts
@@ -47,6 +47,8 @@ export class Proof {
 
   integritySha?: string = undefined;
 
+  parentAssetCid?: string = undefined;
+
   /**
    * Since capture cam originally capture photos/videos from camera we set cameraSource to
    * CameraSource.Camera by default. If user picks photo/video from galley then cameraSource
@@ -164,6 +166,7 @@ export class Proof {
     proof.isCollected = indexedProofView.isCollected ?? false;
     proof.signatureVersion = indexedProofView.signatureVersion;
     proof.integritySha = indexedProofView.integritySha;
+    proof.parentAssetCid = indexedProofView.parentAssetCid;
     proof.cameraSource = indexedProofView.cameraSource;
     return proof;
   }
@@ -335,6 +338,7 @@ export class Proof {
       uploadedAt: this.uploadedAt,
       isCollected: this.isCollected,
       integritySha: this.integritySha,
+      parentAssetCid: this.parentAssetCid,
       cameraSource: this.cameraSource,
     };
   }
@@ -471,6 +475,7 @@ export interface IndexedProofView extends Tuple {
   readonly uploadedAt?: string;
   readonly isCollected?: boolean;
   readonly integritySha?: string;
+  readonly parentAssetCid?: string;
   readonly cameraSource: CameraSource;
 }
 

--- a/src/app/shared/share/share.service.ts
+++ b/src/app/shared/share/share.service.ts
@@ -46,7 +46,7 @@ export class ShareService {
         .pipe(catchError((err: unknown) => this.errorService.toastError$(err)))
         .toPromise();
     }
-    return getAssetProfileForNSE(asset.id);
+    return getAssetProfileForNSE(asset.parent_asset_cid || asset.id);
   }
 
   async shareReferralCode(referralCode: string) {


### PR DESCRIPTION
### Changed
1. Link the asset profile to the parent asset instead of the child asset [#3253](https://github.com/numbersprotocol/capture-lite/pull/3253)

​
┆The issue is also created on [Asana](https://app.asana.com/0/1201016280880500/1208350169750705)