### PR TITLE
Rename variable usernameTranlation to usernameTranslation

### DIFF
--- a/src/app/features/signup/signup.page.ts
+++ b/src/app/features/signup/signup.page.ts
@@ -49,14 +49,14 @@ export class SignupPage {
         tap(
           ([
             emailTranslation,
-            usernameTranlation,
+            usernameTranslation,
             passwordTranslation,
             confirmPasswordTranslation,
             referralCodeOptionalTranslation,
           ]) =>
             this.createFormFields(
               emailTranslation,
-              usernameTranlation,
+              usernameTranslation,
               passwordTranslation,
               confirmPasswordTranslation,
               referralCodeOptionalTranslation
@@ -69,7 +69,7 @@ export class SignupPage {
 
   private createFormFields(
     emailTranslation: string,
-    usernameTranlation: string,
+    usernameTranslation: string,
     passwordTranslation: string,
     confirmPasswordTranslation: string,
     referralCodeOptionalTranslation: string
@@ -133,7 +133,7 @@ export class SignupPage {
             type: 'input',
             templateOptions: {
               type: 'text',
-              placeholder: usernameTranlation,
+              placeholder: usernameTranslation,
               required: true,
               hideRequiredMarker: true,
             },


### PR DESCRIPTION
Fixes #3246

Rename the variable 'usernameTranlation' to 'usernameTranslation' in the `src/app/features/signup/signup.page.ts` file.

* Rename the variable in the `combineLatest` observable in the constructor.
* Rename the variable in the `createFormFields` method.
* Update the placeholder property in the form field configuration to use the renamed variable.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/numbersprotocol/capture-lite/pull/3327?shareId=db070bbc-1e4f-4205-8765-9d35d6394508).

​
┆The issue is also created on [Asana](https://app.asana.com/1/1200886955782960/project/1201016280880500/task/1209649717928331)