### PR TITLE
fix(auth): Hide Google login on iOS

### DIFF
--- a/src/app/features/login/login.page.html
+++ b/src/app/features/login/login.page.html
@@ -14,6 +14,7 @@
   </form>
 
   <app-social-login-button
+    *ngIf="!isIOS"
     [buttonText]="t('continueWithGoogle')"
   ></app-social-login-button>
 

--- a/src/app/features/login/login.page.ts
+++ b/src/app/features/login/login.page.ts
@@ -4,6 +4,7 @@ import { UntypedFormGroup } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AlertController } from '@ionic/angular';
+import { Capacitor } from '@capacitor/core';
 import { TranslocoService } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { FormlyFieldConfig } from '@ngx-formly/core';
@@ -36,6 +37,8 @@ export class LoginPage {
   fields: FormlyFieldConfig[] = [];
 
   showResendEmailButton = false;
+
+  readonly isIOS = Capacitor.getPlatform() === 'ios';
 
   constructor(
     private readonly blockingActionService: BlockingActionService,

--- a/src/app/features/signup/signup.page.html
+++ b/src/app/features/signup/signup.page.html
@@ -18,6 +18,7 @@
   </form>
 
   <app-social-login-button
+    *ngIf="!isIOS"
     [buttonText]="t('continueWithGoogle')"
   ></app-social-login-button>
 

--- a/src/app/features/signup/signup.page.ts
+++ b/src/app/features/signup/signup.page.ts
@@ -2,6 +2,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
+import { Capacitor } from '@capacitor/core';
 import { TranslocoService } from '@ngneat/transloco';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { FormlyFieldConfig } from '@ngx-formly/core';
@@ -30,6 +31,8 @@ export class SignupPage {
   };
 
   fields: FormlyFieldConfig[] = [];
+
+  readonly isIOS = Capacitor.getPlatform() === 'ios';
 
   constructor(
     private readonly blockingActionService: BlockingActionService,


### PR DESCRIPTION
Hide Google login button on iOS platforms in both login and signup pages to prevent App Store rejection when Apple login is not implemented.