### PR TITLE
fix: details page slide nav and iframe permissions

### DIFF
--- a/src/app/features/data-policy/data-policy.page.html
+++ b/src/app/features/data-policy/data-policy.page.html
@@ -12,6 +12,7 @@
   <iframe
     [src]="dataPolicyUrl | safeResourceUrl"
     class="bubble-iframe"
+    allow="accelerometer; gyroscope"
   ></iframe>
   <ion-spinner
     *ngIf="(iframeLoaded$ | async) !== true"

--- a/src/app/features/home/activities/network-action-order-details/network-action-order-details.page.html
+++ b/src/app/features/home/activities/network-action-order-details/network-action-order-details.page.html
@@ -7,7 +7,11 @@
 
 <ng-template #onlineTemplate>
   <ng-container *ngIf="iframeUrl$ | ngrxPush as iframeUrl">
-    <iframe [src]="iframeUrl | safeResourceUrl"> </iframe>
+    <iframe
+      [src]="iframeUrl | safeResourceUrl"
+      allow="accelerometer; gyroscope"
+    >
+    </iframe>
   </ng-container>
   <ion-spinner
     *ngIf="(iframeLoaded$ | async) !== true"

--- a/src/app/features/home/collection-tab/collection-tab/collection-tab.component.html
+++ b/src/app/features/home/collection-tab/collection-tab/collection-tab.component.html
@@ -16,6 +16,7 @@
       #collectionIframe
       [src]="bubbleIframeUrlWithCachedJWTToken"
       class="bubble-iframe"
+      allow="accelerometer; gyroscope"
     ></iframe>
   </div>
 </ng-template>

--- a/src/app/features/home/details/capture-details-with-iframe/capture-details-with-iframe.component.html
+++ b/src/app/features/home/details/capture-details-with-iframe/capture-details-with-iframe.component.html
@@ -2,7 +2,7 @@
 <ng-container *ngIf="networkConnected$ | ngrxPush; else noNetworkText">
   <!-- Display iframe if the iframeUrl is available -->
   <ng-container *ngIf="iframeUrl$ | ngrxPush as iframeUrl">
-    <iframe [src]="iframeUrl"></iframe>
+    <iframe [src]="iframeUrl" allow="accelerometer; gyroscope"></iframe>
   </ng-container>
   <!-- Display spinner while iframe is loading -->
   <ion-spinner *ngIf="!(iframeLoaded$ | ngrxPush)" name="lines-sharp">

--- a/src/app/features/home/details/details.page.ts
+++ b/src/app/features/home/details/details.page.ts
@@ -261,7 +261,12 @@ export class DetailsPage {
 
     this.initialSlideIndex$
       .pipe(
-        tap(index => (this.activeSlideIndex = index)),
+        tap(index => {
+          this.activeSlideIndex = index;
+          // Slide to the correct index after it's calculated
+          // Use setTimeout to ensure the swiper is fully initialized
+          setTimeout(() => this.slideToInitialIndex(), 0);
+        }),
         untilDestroyed(this)
       )
       .subscribe();
@@ -282,9 +287,21 @@ export class DetailsPage {
   }
 
   async ionViewDidEnter() {
+    // Programmatically slide to the initial index after the view enters
+    // This is needed because Swiper's initialSlide property may not work
+    // reliably when the swiper is rendered with *ngrxLet directives
+    this.slideToInitialIndex();
+
     await this.userGuideService.showUserGuidesOnDetailsPage();
     await this.userGuideService.setHasOpenedDetailsPage(true);
     await this.userGuideService.setHasClickedDetailsPageOptionsMenu(true);
+  }
+
+  private slideToInitialIndex() {
+    const swiper = this.swiperRef?.nativeElement?.swiper as Swiper | undefined;
+    if (swiper && this.activeSlideIndex > 0) {
+      swiper.slideTo(this.activeSlideIndex, 0); // 0 = no animation
+    }
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/src/app/features/home/details/edit-caption/edit-caption.page.html
+++ b/src/app/features/home/details/edit-caption/edit-caption.page.html
@@ -1,5 +1,9 @@
 <ion-content>
   <div *ngIf="iframeUrl$ | ngrxPush as iframeUrl">
-    <iframe [src]="iframeUrl" frameborder="0"></iframe>
+    <iframe
+      [src]="iframeUrl"
+      frameborder="0"
+      allow="accelerometer; gyroscope"
+    ></iframe>
   </div>
 </ion-content>

--- a/src/app/features/terms-of-use/terms-of-use.page.html
+++ b/src/app/features/terms-of-use/terms-of-use.page.html
@@ -12,6 +12,7 @@
   <iframe
     [src]="termsOfUseUrl | safeResourceUrl"
     class="bubble-iframe"
+    allow="accelerometer; gyroscope"
   ></iframe>
   <ion-spinner
     *ngIf="(iframeLoaded$ | async) !== true"

--- a/src/app/features/wallets/wallets.page.html
+++ b/src/app/features/wallets/wallets.page.html
@@ -19,5 +19,6 @@
   <iframe
     [src]="iframeUrl$ | async | safeResourceUrl"
     class="bubble-iframe"
+    allow="accelerometer; gyroscope"
   ></iframe>
 </ng-template>


### PR DESCRIPTION
Ref #3364

- Fix asset detail page always showing first image by adding slideTo() to navigate swiper programmatically
- Add allow="accelerometer; gyroscope" to all Bubble iframes to resolve deviceorientation permission errors