### PR TITLE
fix: upgrade Swiper 9→12, fix detail iframes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "process": "^0.11.10",
         "rxjs": "^7.8.2",
         "stream-browserify": "^2.0.2",
-        "swiper": "^9.4.1",
+        "swiper": "^12.1.2",
         "tslib": "^2.3.1",
         "web3": "^4.15.0",
         "zone.js": "^0.14.10"
@@ -19512,12 +19512,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ssr-window": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
-      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==",
-      "license": "MIT"
-    },
     "node_modules/ssri": {
       "version": "10.0.6",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
@@ -20344,9 +20338,9 @@
       "dev": true
     },
     "node_modules/swiper": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-9.4.1.tgz",
-      "integrity": "sha512-1nT2T8EzUpZ0FagEqaN/YAhRj33F2x/lN6cyB0/xoYJDMf8KwTFT3hMOeoB8Tg4o3+P/CKqskP+WX0Df046fqA==",
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.1.2.tgz",
+      "integrity": "sha512-4gILrI3vXZqoZh71I1PALqukCFgk+gpOwe1tOvz5uE9kHtl2gTDzmYflYCwWvR4LOvCrJi6UEEU+gnuW5BtkgQ==",
       "funding": [
         {
           "type": "patreon",
@@ -20358,9 +20352,6 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "ssr-window": "^4.0.2"
-      },
       "engines": {
         "node": ">= 4.7.0"
       }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "process": "^0.11.10",
     "rxjs": "^7.8.2",
     "stream-browserify": "^2.0.2",
-    "swiper": "^9.4.1",
+    "swiper": "^12.1.2",
     "tslib": "^2.3.1",
     "web3": "^4.15.0",
     "zone.js": "^0.14.10"

--- a/src/app/features/home/capture-tab/capture-tab.component.html
+++ b/src/app/features/home/capture-tab/capture-tab.component.html
@@ -4,7 +4,6 @@
   </ion-refresher>
 
   <mat-card
-    appearance="outlined"
     *transloco="let t"
     class="user-card"
     id="user-card"

--- a/src/app/features/home/capture-tab/capture-tab.component.scss
+++ b/src/app/features/home/capture-tab/capture-tab.component.scss
@@ -16,6 +16,9 @@ mat-card {
   width: 100%;
   padding: 0 0 8px;
   box-shadow: none;
+  border: none;
+  outline: none;
+  border-radius: 0;
   background-size: cover !important; /* stylelint-disable-line declaration-no-important */
   background-position: center center !important; /* stylelint-disable-line declaration-no-important */
 

--- a/src/app/features/home/details/details.page.html
+++ b/src/app/features/home/details/details.page.html
@@ -28,14 +28,12 @@
   <swiper-container
     #swiper
     *ngrxLet="initialSlideIndex$ as initialSlideIndex"
-    [virtual]="true"
-    [initialSlide]="initialSlideIndex"
-    [resistanceRatio]="0"
-    [observeSlideChildren]="true"
-    [resizeObserver]="true"
-    [observeParents]="true"
+    [attr.initial-slide]="initialSlideIndex"
+    resistance-ratio="0"
+    observe-slide-children="true"
+    resize-observer="true"
+    observe-parents="true"
     class="swiper"
-    (swiperslidechange)="onSlidesChanged()"
   >
     <swiper-slide
       *ngFor="
@@ -51,9 +49,12 @@
           [detailedCapture]="detailedCapture"
         ></app-capture-details-with-ionic>
 
-        <!-- Show capture details with an iframe when capture is uploaded and the network is connected -->
+        <!-- Show capture details with an iframe only for active slide (and adjacent slides for smoother swiping) -->
         <app-capture-details-with-iframe
-          *ngIf="(showCaptureDetailsInIframe$ | ngrxPush) === true"
+          *ngIf="
+            (showCaptureDetailsInIframe$ | ngrxPush) === true &&
+            isSlideNearActive(i)
+          "
           [detailedCapture]="detailedCapture"
           [slideIsActive]="activeSlideIndex === i"
         ></app-capture-details-with-iframe>

--- a/src/app/features/settings/go-pro/go-pro-media-item-detail-on-camera/go-pro-media-item-detail-on-camera.component.html
+++ b/src/app/features/settings/go-pro/go-pro-media-item-detail-on-camera/go-pro-media-item-detail-on-camera.component.html
@@ -38,7 +38,7 @@
 
   <swiper-container
     #swiper
-    [pagination]="true"
+    pagination="true"
     *ngIf="showTutorialForMobileDataOnlyApps"
   >
     <swiper-slide>

--- a/src/global.scss
+++ b/src/global.scss
@@ -29,7 +29,7 @@
 @import '@ionic/angular/css/palettes/dark.class.css';
 
 /* Swiper */
-@import 'swiper/scss';
+@import 'swiper/swiper-bundle.css';
 
 @font-face {
   font-family: 'Space Grotesk';


### PR DESCRIPTION
Ref #3364

Swiper 9.4.1 → 12.1.2:
- Fix prototype pollution vulnerability GHSA-hmx5-qpq5-p643
- CSS import: swiper/scss → swiper/swiper-bundle.css
- Use kebab-case attrs for Swiper Element web component
- Static pagination attr for go-pro component

Details page iframe rendering:
- Remove virtual slides (incompatible with *ngFor)
- Render iframes only for active ±1 slides
- Use swiper.on('slideChange') instead of Angular event
- Add retry logic for swiper init timing
- detectChanges() for out-of-zone Swiper events

Profile card (Material 18 MDC):
- Remove appearance="outlined" (caused border artifact)
- Reset border/outline/border-radius on mat-card