### PR TITLE
[Omni] Temporarily hide network action orders

### DIFF
--- a/src/app/features/home/activities/activities.page.html
+++ b/src/app/features/home/activities/activities.page.html
@@ -15,6 +15,10 @@
         {{ t('captureTransactions') }}
       </ion-label>
     </ion-segment-button>
+    <!--
+      Temporarily hidden: Network Action Orders tab.
+      NUMBERS_BUBBLE_DB_URL is no longer supported; this will be
+      re-wired through the backend in a future iteration.
     <ion-segment-button
       value="networkActionOrders"
       joyrideStep="highlightNetworkActionsTab"
@@ -25,14 +29,18 @@
         {{ t('orders') }}
       </ion-label>
     </ion-segment-button>
+    -->
   </ion-segment>
 
   <div class="page-content">
     <div *ngIf="segment.value === 'transactions'">
       <app-capture-transactions></app-capture-transactions>
     </div>
+    <!--
+      Temporarily hidden together with the "Orders" segment above.
     <div *ngIf="segment.value === 'networkActionOrders'">
       <app-network-action-orders></app-network-action-orders>
     </div>
+    -->
   </div>
 </ion-content>

--- a/src/app/features/home/details/details.page.ts
+++ b/src/app/features/home/details/details.page.ts
@@ -505,12 +505,16 @@ export class DetailsPage {
     combineLatest([
       this.networkConnected$,
       this.activeDetailedCapture$,
-      this.postCreationWorkflowCompleted$,
+      // this.postCreationWorkflowCompleted$ temporarily removed —
+      // only needed for the Network Actions menu entry which is
+      // hidden while NUMBERS_BUBBLE_DB_URL is unsupported.
       this.isCollectedCapture$,
       this.translocoService.selectTranslateObject({
         'details.actions.edit': null,
         'details.actions.unpublish': null,
-        'details.actions.networkActions': null,
+        // 'details.actions.networkActions' temporarily omitted —
+        // NUMBERS_BUBBLE_DB_URL is no longer supported. The Network
+        // Actions entry will be re-wired through the backend later.
         'details.actions.remove': null,
       }),
     ])
@@ -520,14 +524,8 @@ export class DetailsPage {
           ([
             networkConnected,
             activeDetailedCapture,
-            postCreationWorkflowCompleted,
             isCollectedCapture,
-            [
-              editActionText,
-              unpublishActionText,
-              networkActionsText,
-              removeActionText,
-            ],
+            [editActionText, unpublishActionText, removeActionText],
           ]) => {
             const buttons: ActionSheetButton[] = [];
 
@@ -551,12 +549,15 @@ export class DetailsPage {
                 handler: () => this.handleUnpublishAction(),
               });
             }
-            if (networkConnected && postCreationWorkflowCompleted) {
-              buttons.push({
-                text: networkActionsText,
-                handler: () => this.handleOpenNetworkActions(),
-              });
-            }
+            // Network Actions menu entry temporarily hidden —
+            // NUMBERS_BUBBLE_DB_URL deprecated. Will be restored once
+            // the feature is re-wired through the backend.
+            // if (networkConnected && postCreationWorkflowCompleted) {
+            //   buttons.push({
+            //     text: networkActionsText,
+            //     handler: () => this.handleOpenNetworkActions(),
+            //   });
+            // }
             buttons.push({
               text: removeActionText,
               handler: () => this.handleRemoveAction(),


### PR DESCRIPTION
## Summary

Network action orders are temporarily hidden from the UI because `NUMBERS_BUBBLE_DB_URL` is no longer supported. This prevents users from seeing broken or unsupported order types. If network action functionality is needed in the future, it will be re-integrated via the backend directly.

## Changes

- Hidden network action order entries in `activities.page.html` to remove them from the activity list view
- Updated `details.page.ts` to exclude network action order handling from the details page logic

---
Generated by Olga Shen with [Omni](https://omniai.one/)

---
Created by Olga Shen & Omni