### PR TITLE
[Omni] Restrict Dependabot updates to production deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: 'weekly'
     target-branch: 'main'
     open-pull-requests-limit: 10
+    # Only automate production dependency updates. Development/build toolchain
+    # advisories are reviewed manually because they often require coordinated
+    # framework upgrades or upstream fixes.
+    allow:
+      - dependency-type: 'production'
     # Skip major-version PRs. Majors for Angular / ngrx / ionic / capacitor etc.
     # always require coordinated framework migrations that Dependabot cannot
     # handle on its own, so we'd just end up with PRs that permanently fail CI.


### PR DESCRIPTION
## Summary
This PR updates the Dependabot configuration to only process production dependencies. This reduces noisy Dependabot update failures caused by non-production dependency types while keeping the intended production dependency update flow intact.

## Changes
- Updated `.github/dependabot.yml` to apply `dependency-type: production` to Dependabot update rules.
- Limited Dependabot update scope so development-only dependencies are not included in the affected update checks.
- Preserved the existing Dependabot schedule and update behavior for production dependencies.
- Note that historical GitHub Actions error records will not be deleted, but new Dependabot runs should stop producing the same non-production dependency-type errors.

---
Generated by Olga Shen with [Omni](https://omniai.one/)