### PR TITLE
ci: normalize Dependabot lockfiles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,42 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      app_changed: ${{ steps.changed-files.outputs.app_changed }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check changed files
+        id: changed-files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          app_changed=false
+
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+
+            case "$file" in
+              .github/*|.omni/*) ;;
+              *) app_changed=true ;;
+            esac
+          done <<EOF
+          $changed_files
+          EOF
+
+          echo "app_changed=$app_changed" >> "$GITHUB_OUTPUT"
+
   android:
+    needs: changes
+    if: needs.changes.outputs.app_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -48,9 +83,10 @@ jobs:
           ./gradlew assembleDebug
 
   ios:
+    needs: changes
     runs-on: macos-26
     timeout-minutes: 60
-    if: github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: needs.changes.outputs.app_changed == 'true' && github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: write
 

--- a/.github/workflows/dependabot-lockfile-normalize.yml
+++ b/.github/workflows/dependabot-lockfile-normalize.yml
@@ -1,0 +1,92 @@
+name: dependabot-lockfile-normalize
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    paths:
+      - package.json
+      - package-lock.json
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: dependabot-lockfile-normalize-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  normalize:
+    name: Normalize npm lockfile
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      ${{
+        github.event.pull_request.user.login == 'dependabot[bot]' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'dependabot/npm_and_yarn/')
+      }}
+
+    steps:
+      - name: Checkout Dependabot branch
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Verify Dependabot branch guard
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          if [ "$PR_AUTHOR" != "dependabot[bot]" ]; then
+            echo "Refusing to run on non-Dependabot PR."
+            exit 1
+          fi
+
+          if [ "$HEAD_REPO" != "$GITHUB_REPOSITORY" ]; then
+            echo "Refusing to run on fork PR."
+            exit 1
+          fi
+
+          case "$HEAD_REF" in
+            dependabot/npm_and_yarn/*) ;;
+            *)
+              echo "Refusing to run on non-npm Dependabot branch: $HEAD_REF"
+              exit 1
+              ;;
+          esac
+
+      - name: Normalize package lock
+        run: npm install --package-lock-only --ignore-scripts
+
+      - name: Commit normalized package lock
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          if git diff --quiet -- package-lock.json; then
+            echo "package-lock.json is already normalized."
+            exit 0
+          fi
+
+          changed_files="$(git diff --name-only)"
+          if [ "$changed_files" != "package-lock.json" ]; then
+            echo "Unexpected files changed:"
+            printf '%s\n' "$changed_files"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package-lock.json
+          git commit -m "chore(deps): normalize package lock"
+          git -c http.extraheader="AUTHORIZATION: bearer ${GITHUB_TOKEN}" push origin "HEAD:${HEAD_REF}"


### PR DESCRIPTION
## Summary
- Add a Dependabot-only lockfile normalization workflow for npm dependency PRs.
- Run `npm install --package-lock-only --ignore-scripts` on same-repo `dependabot/npm_and_yarn/*` branches.
- Commit back only when `package-lock.json` changes, and fail if any other file changes.
- Add a lightweight `build.yml` changed-files gate so workflow-only PRs skip native Android/iOS build jobs via job-level `if` conditions instead of path-filtering the whole workflow.

## Safety
- Uses `pull_request_target` only with job-level guards for `dependabot[bot]`, same-repo PRs, and npm Dependabot branch prefix.
- Checkout uses `persist-credentials: false`; the normalization step has no explicit token or secrets in its environment.
- Uses `--ignore-scripts` to avoid package lifecycle scripts.
- Limits `GITHUB_TOKEN` permissions to `contents: write` and `pull-requests: read`.
- Uses `actions/checkout@v7`, verified upstream tag exists, for the sensitive `pull_request_target` checkout path.
- Keeps `build.yml` native build checks as jobs, so skipped workflow-only builds report job-level success instead of leaving required workflow checks pending.

## Verification
- `python3 -c 'import yaml; ...'`
- `npx prettier --check .github/workflows/build.yml .github/workflows/dependabot-lockfile-normalize.yml`
- `npm install --package-lock-only --ignore-scripts`
- `npm ci --ignore-scripts --dry-run`
- Dependabot guard simulation for allowed and refused cases
- build changed-files simulation: workflow-only diff returns `app_changed=false`
- `npm run lint`
- `node set-secret.js`
- `npx ng build --configuration production`
