### PR TITLE
ci: limit workflow token permissions

### DIFF
--- a/.github/workflows/build-apks.yml
+++ b/.github/workflows/build-apks.yml
@@ -8,6 +8,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-apks-upload-google-drive:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/firebase-release.yml
+++ b/.github/workflows/firebase-release.yml
@@ -18,6 +18,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   distribute-android:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
 
+permissions:
+  contents: read
+
 jobs:
   build-android-qa:
     runs-on: ubuntu-latest
@@ -63,6 +66,9 @@ jobs:
   upload-android-qa:
     runs-on: ubuntu-latest
     needs: build-android-qa
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v6
 
@@ -307,6 +313,9 @@ jobs:
   create-github-release:
     runs-on: ubuntu-latest
     needs: [deploy-play-store, get-ios-build-number]
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     name: Add issue to Backlog project

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: test
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/uiux-release.yml
+++ b/.github/workflows/uiux-release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - uiux
 
+permissions:
+  contents: read
+
 jobs:
   upload-google-drive:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Fix the CodeQL warning reported on PR #3498 by adding explicit workflow-level GITHUB_TOKEN permissions.
- Add `contents: read` to workflows that only need repository read access.
- Keep `contents: write` only where release assets or branch writes require it: the existing Dependabot lockfile normalization workflow, the iOS build job in `build.yml`, and the GitHub Release upload jobs in `pre-release.yml`.

## Verification

- `npx --no-install prettier --check .github/workflows/*.yml`
- `git diff --check`
- verified every `.github/workflows/*.yml` has a top-level `permissions` block before `jobs:`
- `npm ci --ignore-scripts --dry-run`

Note: `ruby` is not installed in the local runner, so YAML parsing with Ruby was unavailable; Prettier successfully parsed and checked all workflow YAML files.
