### PR TITLE
ci: make Dependabot PR checks visible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       app_changed: ${{ steps.changed-files.outputs.app_changed }}
+      ios_changed: ${{ steps.changed-files.outputs.ios_changed }}
 
     steps:
       - uses: actions/checkout@v6
@@ -27,19 +28,25 @@ jobs:
         run: |
           changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
           app_changed=false
+          ios_changed=false
 
           while IFS= read -r file; do
             [ -n "$file" ] || continue
 
             case "$file" in
               .github/*|.omni/*) ;;
-              *) app_changed=true ;;
+              package-lock.json) app_changed=true ;;
+              *)
+                app_changed=true
+                ios_changed=true
+                ;;
             esac
           done <<EOF
           $changed_files
           EOF
 
           echo "app_changed=$app_changed" >> "$GITHUB_OUTPUT"
+          echo "ios_changed=$ios_changed" >> "$GITHUB_OUTPUT"
 
   android:
     needs: changes
@@ -93,7 +100,7 @@ jobs:
     needs: changes
     runs-on: macos-26
     timeout-minutes: 60
-    if: needs.changes.outputs.app_changed == 'true' && github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: needs.changes.outputs.ios_changed == 'true' && github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: write
 

--- a/.github/workflows/dependabot-lockfile-normalize.yml
+++ b/.github/workflows/dependabot-lockfile-normalize.yml
@@ -119,42 +119,44 @@ jobs:
           auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')"
           git -c http.extraheader="AUTHORIZATION: basic ${auth_header}" push origin "HEAD:${HEAD_REF}"
 
-          # GITHUB_TOKEN pushes do not trigger push workflows, so dispatch tests
-          # explicitly against the normalized Dependabot branch.
-          gh workflow run test.yml --ref "$HEAD_REF"
+          # GITHUB_TOKEN pushes create approval-required pull_request runs.
+          # Approve only the expected workflows for this exact normalized SHA.
+          for workflow_path in \
+            ".github/workflows/build.yml" \
+            ".github/workflows/test.yml"
+          do
+            workflow_run_found=false
 
-          # GitHub creates pull_request workflows from GITHUB_TOKEN updates in
-          # an approval-required state. Approve only build.yml for this exact SHA.
-          build_run_found=false
-          for attempt in $(seq 1 15); do
-            build_run="$(
-              gh api --method GET \
-                "repos/${GITHUB_REPOSITORY}/actions/runs" \
-                -f event=pull_request \
-                -f head_sha="$normalized_sha" \
-                -f per_page=100 \
-                --jq '.workflow_runs[] | select(.path == ".github/workflows/build.yml") | [.id, .status, (.conclusion // "")] | @tsv' \
-                | head -n 1
-            )"
+            for attempt in $(seq 1 15); do
+              workflow_run="$(
+                gh api --method GET \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs" \
+                  -f event=pull_request \
+                  -f head_sha="$normalized_sha" \
+                  -f per_page=100 \
+                  --jq ".workflow_runs[] | select(.path == \"${workflow_path}\") | [.id, .status, (.conclusion // \"\")] | @tsv" \
+                  | head -n 1
+              )"
 
-            if [ -n "$build_run" ]; then
-              build_run_found=true
-              IFS=$'\t' read -r build_run_id build_run_status build_run_conclusion <<< "$build_run"
+              if [ -n "$workflow_run" ]; then
+                workflow_run_found=true
+                IFS=$'\t' read -r workflow_run_id workflow_run_status workflow_run_conclusion <<< "$workflow_run"
 
-              if [ "$build_run_conclusion" = "action_required" ]; then
-                gh api --method POST \
-                  "repos/${GITHUB_REPOSITORY}/actions/runs/${build_run_id}/approve"
-                echo "Approved build workflow run ${build_run_id}."
-              else
-                echo "Build workflow run ${build_run_id} is ${build_run_status}/${build_run_conclusion:-pending}."
+                if [ "$workflow_run_conclusion" = "action_required" ]; then
+                  gh api --method POST \
+                    "repos/${GITHUB_REPOSITORY}/actions/runs/${workflow_run_id}/approve"
+                  echo "Approved ${workflow_path} run ${workflow_run_id}."
+                else
+                  echo "${workflow_path} run ${workflow_run_id} is ${workflow_run_status}/${workflow_run_conclusion:-pending}."
+                fi
+                break
               fi
-              break
+
+              sleep 2
+            done
+
+            if [ "$workflow_run_found" != "true" ]; then
+              echo "No ${workflow_path} run appeared for normalized commit ${normalized_sha}."
+              exit 1
             fi
-
-            sleep 2
           done
-
-          if [ "$build_run_found" != "true" ]; then
-            echo "No build workflow run appeared for normalized commit ${normalized_sha}."
-            exit 1
-          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: test
 
 on:
   push:
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -24,7 +26,11 @@ jobs:
         run: npm install -g @ionic/cli
 
       - name: Normalize Dependabot package lock
-        if: startsWith(github.ref_name, 'dependabot/npm_and_yarn/')
+        if: >-
+          ${{
+            startsWith(github.ref_name, 'dependabot/npm_and_yarn/') ||
+            github.event.pull_request.user.login == 'dependabot[bot]'
+          }}
         run: npm install --package-lock-only --ignore-scripts
 
       - name: Install dependencies
@@ -49,7 +55,11 @@ jobs:
         run: npm install -g @ionic/cli
 
       - name: Normalize Dependabot package lock
-        if: startsWith(github.ref_name, 'dependabot/npm_and_yarn/')
+        if: >-
+          ${{
+            startsWith(github.ref_name, 'dependabot/npm_and_yarn/') ||
+            github.event.pull_request.user.login == 'dependabot[bot]'
+          }}
         run: npm install --package-lock-only --ignore-scripts
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: test
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Upload coverage reports
         uses: codacy/codacy-coverage-reporter-action@master
-        if: github.actor != 'dependabot[bot]'
+        if: github.actor != 'dependabot[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: ./coverage/cobertura-coverage.xml

--- a/package-lock.json
+++ b/package-lock.json
@@ -5020,9 +5020,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5137,9 +5137,9 @@
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10665,9 +10665,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13003,9 +13003,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13126,9 +13126,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14399,9 +14399,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16309,9 +16309,9 @@
       "license": "MIT"
     },
     "node_modules/karma-coverage/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16405,9 +16405,9 @@
       "license": "MIT"
     },
     "node_modules/karma/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
### Summary

- run `test.yml` on `pull_request` so `lint` and `test` are associated with the PR final SHA
- approve both exact-SHA `build.yml` and `test.yml` runs after lockfile normalization
- update vulnerable `brace-expansion` lock entries within their existing semver ranges
- skip Apple signing for lockfile-only PRs while retaining Android, lint, test, and CodeQL coverage

### Root causes

PRs #3504, #3505, and #3506 had successful final-SHA `lint` and `test` jobs, but those jobs were launched through `workflow_dispatch`, so they did not appear in the PR check rollup. Dependabot security update run 29794353170 also failed because the lockfile still resolved `brace-expansion` to vulnerable versions 1.1.14 and 5.0.5.

A lockfile-only validation run also showed that Apple provisioning can fail independently after the app build succeeds. The changed-file gate now reserves signed iOS archives for changes beyond workflow metadata and `package-lock.json`; `package.json` and source/native changes still trigger iOS.

### Verification

- `npm ci`
- `npm run lint`
- `npm ci --ignore-scripts --dry-run`
- workflow Prettier checks
- `npm audit --json` no longer reports `brace-expansion`
- PR CI: lint, test, Android, and CodeQL pass; iOS skipped as intended for this lockfile-only change
- #3504, #3505, and #3506 final-SHA check rollups now include passing `lint` and `test` jobs
- `git diff --check`